### PR TITLE
Signature fixes according http2 spec

### DIFF
--- a/btc-lsp/README.md
+++ b/btc-lsp/README.md
@@ -31,9 +31,13 @@ Every `btc-lsp` gRPC request/response does have `ctx` (context) field in payload
 - First is `nonce`.  The nonce is used for security reasons and is used to guard against replay attacks. The server will reject any request that comes with an incorrect nonce. The only requirement for the nonce is that it needs to be strictly increasing. Nonce generation is often achieved by using the current UNIX timestamp.
 - Second is `ln_pub_key`. This is lightning node network identity public key in DER format. This key is used to verify request/response signature from headers/trailers.
 
-Also every request/response does have a signature:
+Also every request/response does have a signature which is:
 
-- Request/response signature is compact, DER-encoded and uses double-sha256 hash. It's located in `compact-2xsha256-sig` header/trailer.
+- Compact.
+- Using DER format.
+- Using double-sha256 hash.
+- Located in `sig-bin` header/trailer.
+- Base64-encoded according official http2 [spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md).
 
 ## Haskell/Nix
 

--- a/btc-lsp/btc-lsp.cabal
+++ b/btc-lsp/btc-lsp.cabal
@@ -94,6 +94,7 @@ library
     , async
     , base >=4.7 && <5
     , base16-bytestring
+    , base64-bytestring >=1.2.1
     , binary
     , bytestring
     , case-insensitive
@@ -218,6 +219,7 @@ executable btc-lsp-exe
     , async
     , base >=4.7 && <5
     , base16-bytestring
+    , base64-bytestring >=1.2.1
     , binary
     , bytestring
     , case-insensitive
@@ -350,6 +352,7 @@ test-suite btc-lsp-test
     , async
     , base >=4.7 && <5
     , base16-bytestring
+    , base64-bytestring >=1.2.1
     , binary
     , bytestring
     , case-insensitive

--- a/btc-lsp/cabal.project
+++ b/btc-lsp/cabal.project
@@ -3,7 +3,13 @@ packages: *.cabal
 allow-newer: http2-grpc-proto-lens:proto-lens,
   signable:proto-lens, signable:proto-lens-runtime,
   http2-grpc-proto-lens:proto-lens, http2-client:http2,
-  lnd-client:aeson, chronos:aeson
+  lnd-client:aeson, chronos:aeson, lnd-client:base64-bytestring,
+  qrcode-juicypixels:base64-bytestring
+  --
+  -- TODO : remove base64-bytestring jailbreak,
+  -- probably need to upgrade qrcode-juicypixels in
+  -- lnd-client. Otherwise some runtime stuff might be broken!
+  --
 
 allow-older: lnd-client:http2-client
 

--- a/btc-lsp/dhall/docker-compose.yolo.dhall
+++ b/btc-lsp/dhall/docker-compose.yolo.dhall
@@ -168,7 +168,7 @@ in  { networks.global.external = True
               ''
               {
                 "port":443,
-                "sig_header_name":"compact-2xsha256-sig",
+                "sig_header_name":"sig-bin",
                 "tls_cert":"${escape ../build/swarm/btc-lsp/cert.pem as Text}",
                 "tls_key":"${escape ../build/swarm/btc-lsp/key.pem as Text}"
               }

--- a/btc-lsp/nix/ds-setup.sh
+++ b/btc-lsp/nix/ds-setup.sh
@@ -9,7 +9,7 @@ mkdir -p "$BUILD_DIR"
 
 echo "==> Docker build cleanup"
 sh "$THIS_DIR/ds-down.sh" || true
-rm -rf "$BUILD_DIR"
+rm -rf "$BUILD_DIR/swarm"
 
 echo "==> Docker swarm network setup"
 if [ "$1" = "--reset-swarm" ]; then

--- a/btc-lsp/nix/ns-export-test-envs.sh
+++ b/btc-lsp/nix/ns-export-test-envs.sh
@@ -143,13 +143,13 @@ export LSP_GRPC_CLIENT_ENV="
   \"port\":8444,
   \"prv_key\":\"$LSP_AGENT_PRIVATE_KEY_PEM\",
   \"pub_key\":\"$LSP_PARTNER_PUBLIC_KEY_PEM\",
-  \"sig_header_name\":\"compact-2xsha256-sig\"
+  \"sig_header_name\":\"sig-bin\"
 }
 "
 export LSP_GRPC_SERVER_ENV="
 {
   \"port\":8444,
-  \"sig_header_name\":\"compact-2xsha256-sig\",
+  \"sig_header_name\":\"sig-bin\",
   \"tls_cert\":\"$GRPC_TLS_CERT\",
   \"tls_key\":\"$GRPC_TLS_KEY\"
 }

--- a/btc-lsp/package.yaml
+++ b/btc-lsp/package.yaml
@@ -60,6 +60,7 @@ dependencies:
 - memory
 - aeson
 - base16-bytestring
+- base64-bytestring >= 1.2.1
 # threads
 - async
 - stm

--- a/btc-lsp/src/BtcLsp/Grpc/Sig.hs
+++ b/btc-lsp/src/BtcLsp/Grpc/Sig.hs
@@ -1,30 +1,60 @@
 module BtcLsp.Grpc.Sig
-  (
-    sigFromReq,
-    prepareMsg
+  ( sigFromReq,
+    prepareMsg,
   )
 where
-import qualified Data.CaseInsensitive as CI
-import Network.Wai.Internal (Request (..))
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString as BS
-import qualified Crypto.Secp256k1 as C
-import Universum
+
+import BtcLsp.Import.External
 import qualified Crypto.Hash as CH
-import qualified Data.ByteArray as BA
+import qualified Crypto.Secp256k1 as C
 import qualified Data.Binary as B
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as B64
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.CaseInsensitive as CI
+import qualified Data.Text as T
+import Network.Wai.Internal (Request (..))
 
-
-
-sigFromReq :: ByteString -> Request -> Maybe C.Sig
+sigFromReq :: SigHeaderName -> Request -> Either Text C.Sig
 sigFromReq sigHeaderName req = do
-  let sigHeaderNameCI = CI.mk sigHeaderName
-  (_, sig) <- find (\x -> fst x == sigHeaderNameCI) $ requestHeaders req
-  C.importSig sig
+  (_, b64sig) <-
+    maybeToRight
+      ( "missing "
+          <> sigHeaderNameText
+          <> " header"
+      )
+      . find (\x -> fst x == sigHeaderNameCI)
+      $ requestHeaders req
+  sigDer <-
+    first
+      ( \e ->
+          "signature "
+            <> sigHeaderNameText
+            <> " import from base64 payload "
+            <> inspectPlain b64sig
+            <> " failed with error "
+            <> T.pack e
+      )
+      $ B64.decode b64sig
+  maybeToRight
+    ( "signature "
+        <> sigHeaderNameText
+        <> " import from der payload "
+        <> inspectPlain sigDer
+        <> " failed"
+    )
+    $ C.importSig sigDer
+  where
+    sigHeaderNameText =
+      from sigHeaderName
+    sigHeaderNameBS =
+      from sigHeaderName
+    sigHeaderNameCI =
+      CI.mk sigHeaderNameBS
 
 prepareMsg :: ByteString -> Maybe C.Msg
 prepareMsg m = C.msg $ BS.pack $ BA.unpack $ hash256 $ (BSL.drop 8 . B.encode) m
   where
     hash256 :: BSL.ByteString -> CH.Digest CH.SHA256
     hash256 = CH.hashlazy
-

--- a/btc-lsp/src/BtcLsp/Import/External.hs
+++ b/btc-lsp/src/BtcLsp/Import/External.hs
@@ -119,8 +119,10 @@ import Text.Casing as X (camel)
 import Text.PrettyPrint.GenericPretty as X (Out (..))
 import Text.PrettyPrint.GenericPretty.Import as X
   ( inspect,
+    inspectGenPlain,
     inspectPlain,
     inspectStr,
+    inspectStrPlain,
   )
 import Text.PrettyPrint.GenericPretty.Instance as X ()
 import Universum as X hiding


### PR DESCRIPTION
- Use text signature (b64 as described in http2 spec)
- Better signature header/trailer name