### PR TITLE
B1 m2 5477

### DIFF
--- a/btc-lsp/btc-lsp.cabal
+++ b/btc-lsp/btc-lsp.cabal
@@ -369,6 +369,7 @@ test-suite btc-lsp-test
       Proto.BtcLsp_Fields
       BlockScannerSpec
       LnChanWatcherSpec
+      MathSpec
       RpcSpec
       ServerSpec
       Spec

--- a/btc-lsp/btc-lsp.cabal
+++ b/btc-lsp/btc-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 
@@ -25,7 +25,6 @@ source-repository head
 
 library
   exposed-modules:
-      BtcLsp.Cfg
       BtcLsp.Class.Env
       BtcLsp.Class.Storage
       BtcLsp.Data.AppM
@@ -45,6 +44,7 @@ library
       BtcLsp.Import.External
       BtcLsp.Import.Psql
       BtcLsp.Import.Witch
+      BtcLsp.Math
       BtcLsp.Rpc.Client
       BtcLsp.Rpc.ElectrsRpc
       BtcLsp.Rpc.Env
@@ -169,7 +169,6 @@ library
 executable btc-lsp-exe
   main-is: Main.hs
   other-modules:
-      BtcLsp.Cfg
       BtcLsp.Class.Env
       BtcLsp.Class.Storage
       BtcLsp.Data.AppM
@@ -189,6 +188,7 @@ executable btc-lsp-exe
       BtcLsp.Import.External
       BtcLsp.Import.Psql
       BtcLsp.Import.Witch
+      BtcLsp.Math
       BtcLsp.Rpc.Client
       BtcLsp.Rpc.ElectrsRpc
       BtcLsp.Rpc.Env
@@ -314,7 +314,6 @@ test-suite btc-lsp-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      BtcLsp.Cfg
       BtcLsp.Class.Env
       BtcLsp.Class.Storage
       BtcLsp.Data.AppM
@@ -334,6 +333,7 @@ test-suite btc-lsp-test
       BtcLsp.Import.External
       BtcLsp.Import.Psql
       BtcLsp.Import.Witch
+      BtcLsp.Math
       BtcLsp.Rpc.Client
       BtcLsp.Rpc.ElectrsRpc
       BtcLsp.Rpc.Env

--- a/btc-lsp/cabal.project
+++ b/btc-lsp/cabal.project
@@ -27,8 +27,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/coingaming/lnd-client.git
-  --sha256: 0yzk5l5gdiy06w1c4bgza4ygk01v2anc6knf85wc3n01hpxrra6m
-  tag: 2b53cc78aa7419549dcc9e1427cef621521ce5e9
+  --sha256: 0ip924z65kgzysmmch99njminsnnmnpkcxfajnpiww0pl1mi0clh
+  tag: 54bf660ccc76f2bc6bc5219f8243b2c2c7e9c590
 
 source-repository-package
   type: git

--- a/btc-lsp/dhall/docker-compose.yolo.dhall
+++ b/btc-lsp/dhall/docker-compose.yolo.dhall
@@ -127,6 +127,7 @@ in  { networks.global.external = True
           , LSP_LOG_SEVERITY = "DebugS"
           , LSP_LND_P2P_HOST = "127.0.0.1"
           , LSP_LND_P2P_PORT = "9735"
+          , LSP_MIN_CHAN_CAP_MSAT = "20000000"
           , -- Rpc
             LSP_LND_ENV =
               ''

--- a/btc-lsp/nix/nix-install-tools.sh
+++ b/btc-lsp/nix/nix-install-tools.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+
+nix-env -i -f "$THIS_DIR/tools.nix"

--- a/btc-lsp/nix/ns-export-test-envs.sh
+++ b/btc-lsp/nix/ns-export-test-envs.sh
@@ -121,6 +121,7 @@ export LSP_LOG_VERBOSITY="V3" # V0-V3
 export LSP_LOG_SEVERITY="DebugS"
 export LSP_LND_P2P_HOST="127.0.0.1"
 export LSP_LND_P2P_PORT="9735"
+export LSP_MIN_CHAN_CAP_MSAT="20000000"
 export LSP_LIBPQ_CONN_STR="postgresql://postgres@localhost/lsp-test"
 
 #

--- a/btc-lsp/nix/ns-export-test-envs.sh
+++ b/btc-lsp/nix/ns-export-test-envs.sh
@@ -186,6 +186,19 @@ export LSP_GRPC_CLIENT_ENV="
 #   \"compress_mode\":\"Compressed\"
 # }
 # "
+#
+# NOTE : for testnet DO k8s tests
+#
+# export LSP_GRPC_CLIENT_ENV="
+# {
+#   \"host\":\"testnet-lsp.coins.io\",
+#   \"port\":8443,
+#   \"prv_key\":\"$LSP_AGENT_PRIVATE_KEY_PEM\",
+#   \"pub_key\":\"$LSP_PARTNER_PUBLIC_KEY_PEM\",
+#   \"sig_header_name\":\"sig-bin\",
+#   \"compress_mode\":\"Compressed\"
+# }
+# "
 
 export LSP_GRPC_SERVER_ENV="
 {

--- a/btc-lsp/nix/tools.nix
+++ b/btc-lsp/nix/tools.nix
@@ -1,0 +1,10 @@
+let nixpkgs = builtins.fetchTarball {
+      url="https://github.com/NixOS/nixpkgs/archive/5dbd4b2b27e24eaed6a79603875493b15b999d4b.tar.gz";
+      sha256="0f6514l8jva85v1g1vvib93691pwr25blzxr4i4vavys5dz6kxnm";
+    };
+    pkgs = import nixpkgs {};
+in
+with pkgs;
+{
+  inherit kubectl minikube doctl;
+}

--- a/btc-lsp/src/BtcLsp/Class/Env.hs
+++ b/btc-lsp/src/BtcLsp/Class/Env.hs
@@ -6,6 +6,7 @@ module BtcLsp.Class.Env
 where
 
 import BtcLsp.Class.Storage
+import BtcLsp.Data.Kind
 import BtcLsp.Data.Type
 import BtcLsp.Grpc.Orphan ()
 import BtcLsp.Grpc.Server.LowLevel
@@ -27,6 +28,7 @@ class
   Env m
   where
   getGsEnv :: m GSEnv
+  getSwapIntoLnMinAmt :: m (Money 'Usr 'OnChain 'Fund)
   getLspPubKeyVar :: m (MVar Lnd.NodePubKey)
   getLndP2PSocketAddress :: m SocketAddress
   getLspPubKey :: m Lnd.NodePubKey

--- a/btc-lsp/src/BtcLsp/Data/AppM.hs
+++ b/btc-lsp/src/BtcLsp/Data/AppM.hs
@@ -45,6 +45,8 @@ instance (MonadIO m) => KatipContext (AppM m) where
 instance (MonadUnliftIO m) => I.Env (AppM m) where
   getGsEnv =
     asks Env.envGrpcServer
+  getSwapIntoLnMinAmt =
+    asks Env.envSwapIntoLnMinAmt
   getLspPubKeyVar =
     asks Env.envLndPubKey
   getLspLndEnv =

--- a/btc-lsp/src/BtcLsp/Data/Env.hs
+++ b/btc-lsp/src/BtcLsp/Data/Env.hs
@@ -74,7 +74,7 @@ data RawConfig = RawConfig
     rawConfigLndEnv :: Lnd.LndEnv,
     rawConfigLndP2PHost :: HostName,
     rawConfigLndP2PPort :: PortNumber,
-    rawConfigMinChanCap :: Money 'Lsp 'Ln 'Fund,
+    rawConfigMinChanCap :: Money 'Chan 'Ln 'Fund,
     -- | Grpc
     rawConfigGrpcServerEnv :: GSEnv,
     -- | Electrs Rpc

--- a/btc-lsp/src/BtcLsp/Data/Env.hs
+++ b/btc-lsp/src/BtcLsp/Data/Env.hs
@@ -10,6 +10,7 @@ module BtcLsp.Data.Env
   )
 where
 
+import BtcLsp.Data.Kind
 import BtcLsp.Data.Type
 import BtcLsp.Grpc.Client.LowLevel
 import BtcLsp.Grpc.Server.LowLevel
@@ -50,6 +51,7 @@ data Env = Env
     envLnd :: Lnd.LndEnv,
     envLndP2PHost :: HostName,
     envLndP2PPort :: PortNumber,
+    envMinChanCap :: Money 'Lsp 'Ln 'Fund,
     envLndPubKey :: MVar Lnd.NodePubKey,
     -- | Grpc
     envGrpcServer :: GSEnv,
@@ -71,6 +73,7 @@ data RawConfig = RawConfig
     rawConfigLndEnv :: Lnd.LndEnv,
     rawConfigLndP2PHost :: HostName,
     rawConfigLndP2PPort :: PortNumber,
+    rawConfigMinChanCap :: Money 'Lsp 'Ln 'Fund,
     -- | Grpc
     rawConfigGrpcServerEnv :: GSEnv,
     -- | Electrs Rpc
@@ -123,6 +126,7 @@ readRawConfig =
       <*> E.var (parseFromJSON <=< E.nonempty) "LSP_LND_ENV" opts
       <*> E.var (E.str <=< E.nonempty) "LSP_LND_P2P_HOST" opts
       <*> E.var (E.auto <=< E.nonempty) "LSP_LND_P2P_PORT" opts
+      <*> E.var (E.auto <=< E.nonempty) "LSP_MIN_CHAN_CAP_MSAT" opts
       -- Grpc
       <*> E.var (parseFromJSON <=< E.nonempty) "LSP_GRPC_SERVER_ENV" opts
       -- Electrs
@@ -190,6 +194,7 @@ withEnv rc this = do
                 envLnd = lnd,
                 envLndP2PHost = rawConfigLndP2PHost rc,
                 envLndP2PPort = rawConfigLndP2PPort rc,
+                envMinChanCap = rawConfigMinChanCap rc,
                 envLndPubKey = pubKeyVar,
                 -- Grpc
                 envGrpcServer =

--- a/btc-lsp/src/BtcLsp/Data/Env.hs
+++ b/btc-lsp/src/BtcLsp/Data/Env.hs
@@ -16,6 +16,7 @@ import BtcLsp.Grpc.Client.LowLevel
 import BtcLsp.Grpc.Server.LowLevel
 import BtcLsp.Import.External
 import qualified BtcLsp.Import.Psql as Psql
+import qualified BtcLsp.Math as Math
 import BtcLsp.Rpc.Env
 import Control.Monad.Logger (runNoLoggingT)
 import qualified Data.Aeson as A (Result (..), Value (..), decode)
@@ -51,7 +52,7 @@ data Env = Env
     envLnd :: Lnd.LndEnv,
     envLndP2PHost :: HostName,
     envLndP2PPort :: PortNumber,
-    envMinChanCap :: Money 'Lsp 'Ln 'Fund,
+    envSwapIntoLnMinAmt :: Money 'Usr 'OnChain 'Fund,
     envLndPubKey :: MVar Lnd.NodePubKey,
     -- | Grpc
     envGrpcServer :: GSEnv,
@@ -194,7 +195,9 @@ withEnv rc this = do
                 envLnd = lnd,
                 envLndP2PHost = rawConfigLndP2PHost rc,
                 envLndP2PPort = rawConfigLndP2PPort rc,
-                envMinChanCap = rawConfigMinChanCap rc,
+                envSwapIntoLnMinAmt =
+                  Math.newSwapIntoLnMinAmt $
+                    rawConfigMinChanCap rc,
                 envLndPubKey = pubKeyVar,
                 -- Grpc
                 envGrpcServer =

--- a/btc-lsp/src/BtcLsp/Data/Kind.hs
+++ b/btc-lsp/src/BtcLsp/Data/Kind.hs
@@ -32,6 +32,7 @@ data BitcoinLayer
 data Owner
   = Lsp
   | Usr
+  | Chan
   deriving
     ( Eq,
       Ord,

--- a/btc-lsp/src/BtcLsp/Data/Orphan.hs
+++ b/btc-lsp/src/BtcLsp/Data/Orphan.hs
@@ -61,7 +61,6 @@ instance From Word32 (Vout 'Funding)
 instance From ByteString (TxId 'Funding)
 
 instance TryFrom Integer (Vout 'Funding) where
-  tryFrom = from `composeTryRhs` tryFrom @Integer @Word32
-
-instance TryFrom Btc.BTC MSat where
-  tryFrom = from `composeTryRhs` tryFrom @Integer @Word64 `composeTryLhs` fmap (* 1000) from
+  tryFrom =
+    from @Word32
+      `composeTryRhs` tryFrom

--- a/btc-lsp/src/BtcLsp/Data/Type.hs
+++ b/btc-lsp/src/BtcLsp/Data/Type.hs
@@ -223,6 +223,7 @@ newtype
     ( Eq,
       Ord,
       Show,
+      Read,
       Num,
       Psql.PersistField,
       Psql.PersistFieldSql

--- a/btc-lsp/src/BtcLsp/Data/Type.hs
+++ b/btc-lsp/src/BtcLsp/Data/Type.hs
@@ -287,6 +287,10 @@ instance From (Ratio Word64) FeeRate
 
 instance From FeeRate (Ratio Word64)
 
+instance From FeeRate (Ratio Natural) where
+  from =
+    via @(Ratio Word64)
+
 instance TryFrom Rational FeeRate where
   tryFrom =
     from @(Ratio Word64)

--- a/btc-lsp/src/BtcLsp/Grpc/Server/HighLevel.hs
+++ b/btc-lsp/src/BtcLsp/Grpc/Server/HighLevel.hs
@@ -6,8 +6,8 @@ module BtcLsp.Grpc.Server.HighLevel
   )
 where
 
-import qualified BtcLsp.Cfg as Cfg
 import BtcLsp.Import
+import qualified BtcLsp.Math as Math
 import qualified BtcLsp.Storage.Model.SwapIntoLn as SwapIntoLn
 import qualified LndClient.Data.NewAddress as Lnd
 import qualified LndClient.Data.PayReq as Lnd
@@ -97,15 +97,15 @@ getCfg _ _ = do
                           .~ from (socketAddressPort sa)
                     ]
                & GetCfg.swapIntoLnMinAmt
-                 .~ from Cfg.swapLnMinAmt
+                 .~ from Math.swapLnMinAmt
                & GetCfg.swapIntoLnMaxAmt
-                 .~ from Cfg.swapLnMaxAmt
+                 .~ from Math.swapLnMaxAmt
                & GetCfg.swapFromLnMinAmt
-                 .~ from Cfg.swapLnMinAmt
+                 .~ from Math.swapLnMinAmt
                & GetCfg.swapFromLnMaxAmt
-                 .~ from Cfg.swapLnMaxAmt
+                 .~ from Math.swapLnMaxAmt
                & GetCfg.swapLnFeeRate
-                 .~ from Cfg.swapLnFeeRate
+                 .~ from Math.swapLnFeeRate
                & GetCfg.swapLnMinFee
-                 .~ from Cfg.swapLnMinFee
+                 .~ from Math.swapLnMinFee
            )

--- a/btc-lsp/src/BtcLsp/Grpc/Server/HighLevel.hs
+++ b/btc-lsp/src/BtcLsp/Grpc/Server/HighLevel.hs
@@ -83,6 +83,7 @@ getCfg ::
 getCfg _ _ = do
   pub <- getLspPubKey
   sa <- getLndP2PSocketAddress
+  swapMinAmt <- getSwapIntoLnMinAmt
   pure $
     defMessage
       & GetCfg.success
@@ -97,11 +98,11 @@ getCfg _ _ = do
                           .~ from (socketAddressPort sa)
                     ]
                & GetCfg.swapIntoLnMinAmt
-                 .~ from Math.swapLnMinAmt
+                 .~ from swapMinAmt
                & GetCfg.swapIntoLnMaxAmt
                  .~ from Math.swapLnMaxAmt
                & GetCfg.swapFromLnMinAmt
-                 .~ from Math.swapLnMinAmt
+                 .~ from swapMinAmt
                & GetCfg.swapFromLnMaxAmt
                  .~ from Math.swapLnMaxAmt
                & GetCfg.swapLnFeeRate

--- a/btc-lsp/src/BtcLsp/Import.hs
+++ b/btc-lsp/src/BtcLsp/Import.hs
@@ -3,7 +3,6 @@ module BtcLsp.Import
   )
 where
 
-import BtcLsp.Cfg as X
 import BtcLsp.Class.Env as X (Env (..))
 import BtcLsp.Class.Storage as X (Storage (..))
 import BtcLsp.Data.Env as X (readRawConfig, withEnv)
@@ -13,6 +12,7 @@ import BtcLsp.Data.Type as X
 import BtcLsp.Grpc.Combinator as X
 import BtcLsp.Grpc.Orphan as X ()
 import BtcLsp.Import.External as X
+import BtcLsp.Math as X
 import BtcLsp.Storage.Model as X hiding (Key (..))
 import BtcLsp.Storage.Util as X
 import BtcLsp.Time as X

--- a/btc-lsp/src/BtcLsp/Import.hs
+++ b/btc-lsp/src/BtcLsp/Import.hs
@@ -12,7 +12,7 @@ import BtcLsp.Data.Type as X
 import BtcLsp.Grpc.Combinator as X
 import BtcLsp.Grpc.Orphan as X ()
 import BtcLsp.Import.External as X
-import BtcLsp.Math as X
+import BtcLsp.Math as X (SwapCap (..), newSwapCapM)
 import BtcLsp.Storage.Model as X hiding (Key (..))
 import BtcLsp.Storage.Util as X
 import BtcLsp.Time as X

--- a/btc-lsp/src/BtcLsp/Math.hs
+++ b/btc-lsp/src/BtcLsp/Math.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeApplications #-}
 
-module BtcLsp.Cfg
+module BtcLsp.Math
   ( SwapCap,
     swapCapUsr,
     swapCapLsp,

--- a/btc-lsp/src/BtcLsp/Thread/BlockScanner.hs
+++ b/btc-lsp/src/BtcLsp/Thread/BlockScanner.hs
@@ -94,12 +94,7 @@ extractRelatedUtxoFromBlock blk =
           case mswp of
             Just swp ->
               newUtxo (tryFrom val) (tryFrom num) txid swp
-            Nothing -> do
-              $(logTM) DebugS . logStr $
-                "Unknown swap in txid: "
-                  <> inspect txid
-                  <> " and txout: "
-                  <> Universum.show txout
+            Nothing ->
               pure Nothing
         _ -> do
           $(logTM) ErrorS . logStr $
@@ -108,12 +103,7 @@ extractRelatedUtxoFromBlock blk =
               <> " and txout: "
               <> Universum.show txout
           pure Nothing
-    mapVout txid txout = do
-      $(logTM) DebugS . logStr $
-        "Unsupported txid: "
-          <> inspect txid
-          <> " and txout: "
-          <> Universum.show txout
+    mapVout _ _ =
       pure Nothing
     newUtxo (Right val) (Right n) txid swp =
       pure . Just $

--- a/btc-lsp/test/BlockScannerSpec.hs
+++ b/btc-lsp/test/BlockScannerSpec.hs
@@ -89,7 +89,11 @@ spec = do
           Btc.sendToAddress
           (\h -> h trAddr amt Nothing Nothing)
       lift $ mine 1 LndLsp
-      expectedAmt <- except $ first (const (FailureInternal "expectedAmt overflow")) $ tryFrom (amt * 2)
+      expectedAmt <-
+        except
+          . first (const (FailureInternal "expectedAmt overflow"))
+          . BlockScanner.trySat2MSat
+          $ amt * 2
       utxos <- BlockScanner.scan
       let (gotAmt :: MSat) = sum $ BlockScanner.utxoValue <$> utxos
       pure (expectedAmt == gotAmt)
@@ -111,7 +115,10 @@ spec = do
           Btc.sendToAddress
           (\h -> h trAddr amt Nothing Nothing)
       lift $ mine 1 LndLsp
-      expectedAmt <- except $ first (const (FailureInternal "expectedAmt overflow")) $ tryFrom (amt * 2)
+      expectedAmt <-
+        except . first (const (FailureInternal "expectedAmt overflow"))
+          . BlockScanner.trySat2MSat
+          $ amt * 2
       utxos <- BlockScanner.scan
       let gotAmt = sum $ BlockScanner.utxoValue <$> utxos
       pure (expectedAmt == gotAmt)

--- a/btc-lsp/test/MathSpec.hs
+++ b/btc-lsp/test/MathSpec.hs
@@ -4,11 +4,38 @@ module MathSpec
 where
 
 import BtcLsp.Import
+import qualified BtcLsp.Math as Math
 import Test.Hspec
 import TestOrphan ()
+import TestWithLndLsp
 
 spec :: Spec
 spec = do
-  focus . it "newSwapIntoLnMinAmt" $ do
-    putStrLn ("hello" :: Text)
-    True `shouldBe` True
+  it "newSwapIntoLnMinAmt abs" $
+    Math.newSwapIntoLnMinAmt 20000000
+      `shouldBe` 12000000
+  it "newSwapIntoLnMinAmt perc" $
+    Math.newSwapIntoLnMinAmt 1000000000
+      `shouldBe` 502009000
+  itEnv "newSwapCapM abs" $ do
+    res <- Math.newSwapCapM 12000000
+    liftIO $
+      res
+        `shouldBe` Just
+          ( SwapCap
+              { swapCapUsr = 10000000,
+                swapCapLsp = 10000000,
+                swapCapFee = 2000000
+              }
+          )
+  itEnv "newSwapCapM perc" $ do
+    res <- Math.newSwapCapM 502009000
+    liftIO $
+      res
+        `shouldBe` Just
+          ( SwapCap
+              { swapCapUsr = 500000000,
+                swapCapLsp = 500000000,
+                swapCapFee = 2009000
+              }
+          )

--- a/btc-lsp/test/MathSpec.hs
+++ b/btc-lsp/test/MathSpec.hs
@@ -1,0 +1,14 @@
+module MathSpec
+  ( spec,
+  )
+where
+
+import BtcLsp.Import
+import Test.Hspec
+import TestOrphan ()
+
+spec :: Spec
+spec = do
+  focus . it "newSwapIntoLnMinAmt" $ do
+    putStrLn ("hello" :: Text)
+    True `shouldBe` True

--- a/btc-lsp/test/ServerSpec.hs
+++ b/btc-lsp/test/ServerSpec.hs
@@ -36,7 +36,7 @@ spec = forM_ [Compressed, Uncompressed] $ \compressMode -> do
             defMessage
               & Proto.val
                 .~ ( defMessage
-                       & LowLevel.val .~ 12002000
+                       & LowLevel.val .~ 12000000
                    )
       let maxAmt :: Proto.LocalBalance =
             defMessage

--- a/btc-lsp/test/ServerSpec.hs
+++ b/btc-lsp/test/ServerSpec.hs
@@ -36,7 +36,7 @@ spec = forM_ [Compressed, Uncompressed] $ \compressMode -> do
             defMessage
               & Proto.val
                 .~ ( defMessage
-                       & LowLevel.val .~ 10000000
+                       & LowLevel.val .~ 12002000
                    )
       let maxAmt :: Proto.LocalBalance =
             defMessage

--- a/btc-lsp/test/TestAppM.hs
+++ b/btc-lsp/test/TestAppM.hs
@@ -93,6 +93,8 @@ runTestApp env app =
 instance (MonadUnliftIO m) => I.Env (TestAppM 'LndLsp m) where
   getGsEnv =
     asks $ envGrpcServer . testEnvLsp
+  getSwapIntoLnMinAmt =
+    asks $ envSwapIntoLnMinAmt . testEnvLsp
   getLspPubKeyVar =
     asks $ envLndPubKey . testEnvLsp
   getLspLndEnv =


### PR DESCRIPTION
- Handle minimal LND channel capacity through LSP_MIN_CHAN_CAP_MSAT env value.
- Better fee and capacity math in Math module
- Remove dangerous `instance TryFrom Btc.BTC MSat` instance,  because `BTC` is not a real type, it's just alias. Implicit multiplication with Integer conversion might hit us very hard later, so instance should not exist. Replaced with `trySat2MSat` function which doing the same thing explicitly.