### PR TITLE
B1 m2 6004

### DIFF
--- a/btc-lsp/btc-lsp.cabal
+++ b/btc-lsp/btc-lsp.cabal
@@ -32,7 +32,9 @@ flag ghcid
 library
   exposed-modules:
       BtcLsp.Class.Env
+      BtcLsp.Class.FromProto
       BtcLsp.Class.Storage
+      BtcLsp.Class.ToProto
       BtcLsp.Data.AppM
       BtcLsp.Data.Env
       BtcLsp.Data.Kind
@@ -241,7 +243,9 @@ executable btc-lsp-exe
   if flag(ghcid)
     other-modules:
         BtcLsp.Class.Env
+        BtcLsp.Class.FromProto
         BtcLsp.Class.Storage
+        BtcLsp.Class.ToProto
         BtcLsp.Data.AppM
         BtcLsp.Data.Env
         BtcLsp.Data.Kind
@@ -457,7 +461,9 @@ executable btc-lsp-integration
   if flag(ghcid)
     other-modules:
         BtcLsp.Class.Env
+        BtcLsp.Class.FromProto
         BtcLsp.Class.Storage
+        BtcLsp.Class.ToProto
         BtcLsp.Data.AppM
         BtcLsp.Data.Env
         BtcLsp.Data.Kind
@@ -644,7 +650,9 @@ executable btc-lsp-prof
   if flag(ghcid)
     other-modules:
         BtcLsp.Class.Env
+        BtcLsp.Class.FromProto
         BtcLsp.Class.Storage
+        BtcLsp.Class.ToProto
         BtcLsp.Data.AppM
         BtcLsp.Data.Env
         BtcLsp.Data.Kind
@@ -858,7 +866,9 @@ test-suite btc-lsp-test
   if flag(ghcid)
     other-modules:
         BtcLsp.Class.Env
+        BtcLsp.Class.FromProto
         BtcLsp.Class.Storage
+        BtcLsp.Class.ToProto
         BtcLsp.Data.AppM
         BtcLsp.Data.Env
         BtcLsp.Data.Kind

--- a/btc-lsp/config/model
+++ b/btc-lsp/config/model
@@ -68,8 +68,8 @@ LnChan
   -- with combination of totalSatoshisSent,
   -- totalSatoshisReceived and transactedAt.
   --
-  totalSatoshisSent MSat
-  totalSatoshisReceived MSat
+  totalSatoshisSent Msat
+  totalSatoshisReceived Msat
   status LnChanStatus
   insertedAt UTCTime
   updatedAt UTCTime

--- a/btc-lsp/integration/IntegrationSpec.hs
+++ b/btc-lsp/integration/IntegrationSpec.hs
@@ -30,8 +30,8 @@ spec = do
     sleep300ms
     gcEnv <- getGCEnv
     res0 <- runExceptT $ do
-      refundAddr <-
-        from
+      refundAddr :: OnChainAddress 'Refund <-
+        unsafeNewOnChainAddress . Lnd.address
           <$> withLndTestT
             LndAlice
             Lnd.newAddress
@@ -49,7 +49,7 @@ spec = do
           LndAlice
           ( defMessage
               & SwapIntoLn.refundOnChainAddress
-                .~ from @(OnChainAddress 'Refund) refundAddr
+                .~ toProto refundAddr
           )
     liftIO $
       res0
@@ -75,7 +75,7 @@ spec = do
           LndAlice
           Lnd.sendCoins
           ( \h ->
-              h (Lnd.SendCoinsRequest fundAddr (MSat 200000000) False)
+              h (Lnd.SendCoinsRequest fundAddr (Msat 200000000) False)
           )
       lift $
         LndTest.lazyConnectNodes (Proxy :: Proxy TestOwner)

--- a/btc-lsp/messages/en.msg
+++ b/btc-lsp/messages/en.msg
@@ -22,7 +22,7 @@ Iso3166v1: gb
 Copy: copy
 Continue: Continue
 Amount: Amount
-Satoshi msat@MSat: #{toMessage msat} satoshi
+Satoshi msat@Msat: #{toMessage msat} satoshi
 Status: Status
 ExpiresAt: Expires at
 InsertedAt: Inserted at
@@ -202,7 +202,7 @@ AboutMathMinMax3 minAmt@Money'Usr'OnChain'Fund: #{minAmt}
 AboutMathMinMax4: satoshi and the maximum is
 AboutMathMinMax5 maxAmt@Money'Usr'OnChain'Fund: #{maxAmt}
 AboutMathMinMax6: satoshi. All UTXOs less than
-AboutMathMinMax7 dustLimit@MSat: #{dustLimit}
+AboutMathMinMax7 dustLimit@Msat: #{dustLimit}
 AboutMathMinMax8: satoshi are considered dust and will be ignored.
 AboutMathLspFee0: The value of
 AboutMathLspFee1: LSP_FEE

--- a/btc-lsp/messages/ru.msg
+++ b/btc-lsp/messages/ru.msg
@@ -22,7 +22,7 @@ Iso3166v1: ru
 Copy: копировать
 Continue: Продолжить
 Amount: Количество
-Satoshi msat@MSat: #{toMessage msat} сатоши
+Satoshi msat@Msat: #{toMessage msat} сатоши
 Status: Статус
 ExpiresAt: Истекает
 InsertedAt: Создано
@@ -202,7 +202,7 @@ AboutMathMinMax3 minAmt@Money'Usr'OnChain'Fund: #{minAmt}
 AboutMathMinMax4: сатоши, и максимальное количество равно
 AboutMathMinMax5 maxAmt@Money'Usr'OnChain'Fund: #{maxAmt}
 AboutMathMinMax6: сатоши. Все монеты меньше чем
-AboutMathMinMax7 dustLimit@MSat: #{dustLimit}
+AboutMathMinMax7 dustLimit@Msat: #{dustLimit}
 AboutMathMinMax8: сатоши считаются пылью и будут игнорироваться.
 AboutMathLspFee0: Значение
 AboutMathLspFee1: КОМИССИЯ_ЛСП

--- a/btc-lsp/nix/ns-spawn-bitcoind.sh
+++ b/btc-lsp/nix/ns-spawn-bitcoind.sh
@@ -9,16 +9,12 @@
 echo "starting bitcoind..."
 bitcoind -fallbackfee=0.0002 -datadir=$BTCD_DIR &
 alias bitcoin-cli="bitcoin-cli -rpcwait -datadir=$BTCD_DIR -rpcport=18443"
-bitcoin-cli createwallet "testwallet"
-bitcoin-cli generatetoaddress 1 "$(bitcoin-cli getnewaddress)"
 bitcoin-cli getblockchaininfo
 echo "bitcoind has been started!"
 
 echo "starting bitcoind2..."
 bitcoind -port=21000 -rpcport=21001 -fallbackfee=0.0002 -datadir=$BTCD2_DIR &
 alias bitcoin-cli-2="bitcoin-cli -rpcwait -datadir=$BTCD2_DIR -rpcport=21001"
-bitcoin-cli-2 createwallet "testwallet"
-bitcoin-cli-2 generatetoaddress 1 "$(bitcoin-cli-2 getnewaddress)"
 bitcoin-cli-2 getblockchaininfo
 echo "bitcoind2 has been started!"
 

--- a/btc-lsp/src/BtcLsp/Class/Env.hs
+++ b/btc-lsp/src/BtcLsp/Class/Env.hs
@@ -6,6 +6,7 @@ module BtcLsp.Class.Env
 where
 
 import BtcLsp.Class.Storage
+import BtcLsp.Class.ToProto
 import BtcLsp.Data.Kind
 import BtcLsp.Data.Type
 import BtcLsp.Grpc.Combinator
@@ -30,7 +31,7 @@ class
   where
   getGsEnv :: m GSEnv
   getSwapIntoLnMinAmt :: m (Money 'Usr 'OnChain 'Fund)
-  getMsatPerByte :: m (Maybe MSat)
+  getMsatPerByte :: m (Maybe Msat)
   getLspPubKeyVar :: m (MVar Lnd.NodePubKey)
   getLndP2PSocketAddress :: m SocketAddress
   getLndNodeUri :: m NodeUri
@@ -74,9 +75,9 @@ class
         & field @"ctx"
           .~ ( defMessage
                  & Proto.nonce
-                   .~ from @Nonce @Proto.Nonce nonce
+                   .~ toProto @Nonce @Proto.Nonce nonce
                  & Proto.lnPubKey
-                   .~ from @Lnd.NodePubKey @Proto.LnPubKey pubKey
+                   .~ toProto @Lnd.NodePubKey @Proto.LnPubKey pubKey
              )
   setGrpcCtxT ::
     ( HasField msg "ctx" Proto.Ctx

--- a/btc-lsp/src/BtcLsp/Class/Env.hs
+++ b/btc-lsp/src/BtcLsp/Class/Env.hs
@@ -17,14 +17,14 @@ import qualified LndClient as Lnd
 import qualified LndClient.Data.GetInfo as Lnd
 import qualified LndClient.Data.WalletBalance as Lnd
 import qualified LndClient.RPC.Katip as Lnd
-import qualified Network.Bitcoin as Btc
 import qualified Proto.BtcLsp.Data.HighLevel as Proto
 import qualified Proto.BtcLsp.Data.HighLevel_Fields as Proto
 
 class
   ( MonadUnliftIO m,
     KatipContext m,
-    Storage m
+    Storage m,
+    BtcEnv m Failure
   ) =>
   Env m
   where
@@ -104,16 +104,6 @@ class
   withLndServerT method =
     withExceptT (const $ newInternalFailure FailureRedacted)
       . withLndT method
-  withBtc ::
-    (Btc.Client -> a) ->
-    (a -> IO b) ->
-    m (Either Failure b)
-  withBtcT ::
-    (Btc.Client -> a) ->
-    (a -> IO b) ->
-    ExceptT Failure m b
-  withBtcT method =
-    ExceptT . withBtc method
   monitorTotalExtOutgoingLiquidity :: Liquidity 'Outgoing -> m ()
   monitorTotalExtIncomingLiquidity :: Liquidity 'Incoming -> m ()
   monitorTotalOnChainLiquidity :: Lnd.WalletBalance -> m ()

--- a/btc-lsp/src/BtcLsp/Class/FromProto.hs
+++ b/btc-lsp/src/BtcLsp/Class/FromProto.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
 module BtcLsp.Class.FromProto

--- a/btc-lsp/src/BtcLsp/Class/FromProto.hs
+++ b/btc-lsp/src/BtcLsp/Class/FromProto.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module BtcLsp.Class.FromProto
+  ( FromProto (..),
+  )
+where
+
+import BtcLsp.Data.Kind
+import BtcLsp.Data.Orphan ()
+import BtcLsp.Data.Type
+import BtcLsp.Import.External
+import Data.ProtoLens.Field
+import qualified LndClient as Lnd
+import qualified Proto.BtcLsp.Data.HighLevel as Proto
+import qualified Proto.BtcLsp.Data.LowLevel as Proto
+
+class ('False ~ (proto == haskell)) => FromProto proto haskell where
+  fromProto :: proto -> haskell
+
+instance FromProto Proto.Nonce Nonce where
+  fromProto =
+    Nonce . unProtoVal
+
+instance FromProto Proto.LnPubKey NodePubKey where
+  fromProto =
+    NodePubKey . unProtoVal
+
+instance FromProto Proto.LnInvoice (LnInvoice mrel) where
+  fromProto =
+    LnInvoice . Lnd.PaymentRequest . unProtoVal
+
+instance FromProto Proto.FundLnInvoice (LnInvoice 'Fund) where
+  fromProto =
+    fromProto @Proto.LnInvoice . unProtoVal
+
+instance FromProto Proto.OnChainAddress (UnsafeOnChainAddress 'Refund) where
+  fromProto =
+    UnsafeOnChainAddress . unProtoVal
+
+instance FromProto Proto.RefundOnChainAddress (UnsafeOnChainAddress 'Refund) where
+  fromProto =
+    fromProto @Proto.OnChainAddress @(UnsafeOnChainAddress 'Refund)
+      . unProtoVal
+
+instance FromProto Proto.Privacy Privacy where
+  fromProto =
+    toEnum . fromEnum
+
+instance FromProto Proto.Msat Msat where
+  fromProto =
+    Msat
+      . from @Word64 @Natural
+      . unProtoVal
+
+-- instance FromProto Proto.FundMoney Msat where
+--   fromProto =
+--     Msat . from . unProtoVal
+
+unProtoVal ::
+  forall proto hs.
+  ( HasField proto "val" hs
+  ) =>
+  proto ->
+  hs
+unProtoVal =
+  (^. field @"val")

--- a/btc-lsp/src/BtcLsp/Class/ToProto.hs
+++ b/btc-lsp/src/BtcLsp/Class/ToProto.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE TypeApplications #-}
+
+module BtcLsp.Class.ToProto
+  ( ToProto (..),
+    newProtoVal,
+  )
+where
+
+import BtcLsp.Data.Kind
+import BtcLsp.Data.Orphan ()
+import BtcLsp.Data.Type
+import BtcLsp.Import.External
+import Data.ProtoLens.Field
+import Data.ProtoLens.Message
+import qualified LndClient as Lnd
+import qualified Proto.BtcLsp.Data.HighLevel as Proto
+import qualified Proto.BtcLsp.Data.LowLevel as Proto
+import qualified Proto.BtcLsp.Data.LowLevel_Fields as LowLevel
+
+class ('False ~ (haskell == proto)) => ToProto haskell proto where
+  toProto :: haskell -> proto
+
+instance ToProto Nonce Proto.Nonce where
+  toProto =
+    newProtoVal
+      . unNonce
+
+instance ToProto NodePubKey Proto.LnPubKey where
+  toProto =
+    newProtoVal
+      . unNodePubKey
+
+instance ToProto Lnd.PaymentRequest Proto.LnInvoice where
+  toProto =
+    newProtoVal
+      . Lnd.unPaymentRequest
+
+instance ToProto (LnInvoice 'Fund) Proto.FundLnInvoice where
+  toProto =
+    newProtoVal
+      . toProto @Lnd.PaymentRequest @Proto.LnInvoice
+      . unLnInvoice
+
+instance ToProto Msat Proto.Msat where
+  toProto =
+    newProtoVal
+      . unsafeFrom @Natural @Word64
+      . unMsat
+
+instance ToProto (Money 'Usr 'OnChain 'Fund) Proto.FundMoney where
+  toProto =
+    newProtoVal
+      . toProto @Msat @Proto.Msat
+      . unMoney
+
+instance ToProto PortNumber Proto.LnPort where
+  toProto =
+    newProtoVal
+      . fromIntegral -- Word16 to Word32 is fine
+
+instance ToProto HostName Proto.LnHost where
+  toProto =
+    newProtoVal
+      . pack
+
+instance ToProto (Money 'Usr btcl 'Fund) Proto.LocalBalance where
+  toProto =
+    newProtoVal
+      . toProto @Msat @Proto.Msat
+      . unMoney
+
+instance ToProto (Money 'Lsp btcl 'Gain) Proto.FeeMoney where
+  toProto =
+    newProtoVal
+      . toProto @Msat @Proto.Msat
+      . unMoney
+
+instance ToProto (Ratio Natural) Proto.Urational where
+  toProto x =
+    defMessage
+      & LowLevel.numerator
+        .~ unsafeFrom @Natural @Word64 (numerator x)
+      & LowLevel.denominator
+        .~ unsafeFrom @Natural @Word64 (denominator x)
+
+instance ToProto FeeRate Proto.FeeRate where
+  toProto =
+    newProtoVal
+      . toProto @(Ratio Natural) @Proto.Urational
+      . unFeeRate
+
+newProtoVal ::
+  forall field proto.
+  ( Message proto,
+    HasField proto "val" field
+  ) =>
+  field ->
+  proto
+newProtoVal x =
+  defMessage
+    & field @"val" .~ x

--- a/btc-lsp/src/BtcLsp/Data/Env.hs
+++ b/btc-lsp/src/BtcLsp/Data/Env.hs
@@ -50,7 +50,7 @@ data Env = Env
     envSQLPool :: Pool Psql.SqlBackend,
     envMinTotalExtOutgoingLiquidity :: Liquidity 'Outgoing,
     envMinTotalExtIncomingLiquidity :: Liquidity 'Incoming,
-    envMinTotalOnChainLiquidity :: MSat,
+    envMinTotalOnChainLiquidity :: Msat,
     -- | Logging
     envKatipNS :: Namespace,
     envKatipCTX :: LogContexts,
@@ -61,7 +61,7 @@ data Env = Env
     envLndP2PHost :: HostName,
     envLndP2PPort :: PortNumber,
     envSwapIntoLnMinAmt :: Money 'Usr 'OnChain 'Fund,
-    envMsatPerByte :: Maybe MSat,
+    envMsatPerByte :: Maybe Msat,
     envLndPubKey :: MVar Lnd.NodePubKey,
     -- | Grpc
     envGrpcServer :: GSEnv,
@@ -75,7 +75,7 @@ data RawConfig = RawConfig
     rawConfigLibpqConnStr :: Psql.ConnectionString,
     rawConfigMinTotalExtOutgoingLiquidity :: Liquidity 'Outgoing,
     rawConfigMinTotalExtIncomingLiquidity :: Liquidity 'Incoming,
-    rawConfigMinTotalOnChainLiquidity :: MSat,
+    rawConfigMinTotalOnChainLiquidity :: Msat,
     -- | Logging
     rawConfigLogEnv :: Text,
     rawConfigLogFormat :: LogFormat,
@@ -88,7 +88,7 @@ data RawConfig = RawConfig
     rawConfigLndP2PHost :: HostName,
     rawConfigLndP2PPort :: PortNumber,
     rawConfigMinChanCap :: Money 'Chan 'Ln 'Fund,
-    rawConfigMsatPerByte :: Maybe MSat,
+    rawConfigMsatPerByte :: Maybe Msat,
     -- | Grpc
     rawConfigGrpcServerEnv :: GSEnv,
     -- | Bitcoind

--- a/btc-lsp/src/BtcLsp/Data/Orphan.hs
+++ b/btc-lsp/src/BtcLsp/Data/Orphan.hs
@@ -55,13 +55,13 @@ instance From Text Lnd.PaymentRequest
 
 instance From Lnd.PaymentRequest Text
 
-instance From Word64 MSat
+instance From Natural Msat
 
-instance From MSat Word64
+instance From Msat Natural
 
-instance From Word64 Lnd.Seconds
+instance From Natural Lnd.Seconds
 
-instance From Lnd.Seconds Word64
+instance From Lnd.Seconds Natural
 
 deriving stock instance Generic Btc.Block
 
@@ -95,13 +95,13 @@ instance Out SomeException where
   doc =
     docPrec 0
 
-instance From Word32 (Vout 'Funding)
+instance From Natural (Vout 'Funding)
 
 instance From ByteString (TxId 'Funding)
 
 instance TryFrom Integer (Vout 'Funding) where
   tryFrom =
-    from @Word32
+    from @Natural
       `composeTryRhs` tryFrom
 
 instance PathPiece UTCTime where
@@ -114,12 +114,12 @@ instance PathPiece UTCTime where
     pack
       . Time.formatISO8601
 
-instance ToMessage MSat where
+instance ToMessage Msat where
   toMessage =
     T.displayRational 1
       . (/ 1000)
       . via @Integer
-      . into @Word64
+      . into @Natural
 
 instance Out (Ratio Natural) where
   docPrec x =

--- a/btc-lsp/src/BtcLsp/Data/Smart.hs
+++ b/btc-lsp/src/BtcLsp/Data/Smart.hs
@@ -17,7 +17,6 @@ import BtcLsp.Data.Type
 import BtcLsp.Import.External
 import qualified BtcLsp.Import.Psql as Psql
 import qualified Data.Text as T
-import qualified LndClient.Data.NewAddress as Lnd
 import qualified Network.Bitcoin.Wallet as Btc
 import qualified Proto.BtcLsp.Data.HighLevel as Proto
 import qualified Proto.BtcLsp.Data.LowLevel as Proto
@@ -39,12 +38,6 @@ newtype OnChainAddress (mrel :: MoneyRelation) = OnChainAddress
     )
 
 instance Out (OnChainAddress mrel)
-
-instance From (OnChainAddress mrel) Text
-
-instance From Lnd.NewAddressResponse (OnChainAddress 'Fund)
-
-instance From Lnd.NewAddressResponse (OnChainAddress 'Gain)
 
 unOnChainAddress :: OnChainAddress mrel -> Text
 unOnChainAddress = unOnChainAddress0

--- a/btc-lsp/src/BtcLsp/Data/Smart.hs
+++ b/btc-lsp/src/BtcLsp/Data/Smart.hs
@@ -1,18 +1,19 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 module BtcLsp.Data.Smart
   ( OnChainAddress,
-    unsafeNewOnChainAddress,
     unOnChainAddress,
+    unsafeNewOnChainAddress,
     newOnChainAddress,
     newOnChainAddressT,
   )
 where
 
 import BtcLsp.Class.Env
+import BtcLsp.Class.ToProto
 import BtcLsp.Data.Kind
 import BtcLsp.Data.Type
-import BtcLsp.Grpc.Orphan
 import BtcLsp.Import.External
 import qualified BtcLsp.Import.Psql as Psql
 import qualified Data.Text as T
@@ -20,7 +21,6 @@ import qualified LndClient.Data.NewAddress as Lnd
 import qualified Network.Bitcoin.Wallet as Btc
 import qualified Proto.BtcLsp.Data.HighLevel as Proto
 import qualified Proto.BtcLsp.Data.LowLevel as Proto
-import qualified Witch
 
 newtype OnChainAddress (mrel :: MoneyRelation) = OnChainAddress
   { unOnChainAddress0 :: Text
@@ -46,20 +46,11 @@ instance From Lnd.NewAddressResponse (OnChainAddress 'Fund)
 
 instance From Lnd.NewAddressResponse (OnChainAddress 'Gain)
 
-instance From (OnChainAddress mrel) Proto.OnChainAddress where
-  from = intoProto
-
-instance From (OnChainAddress 'Refund) Proto.RefundOnChainAddress where
-  from = intoProto
-
-instance From (OnChainAddress 'Fund) Proto.FundOnChainAddress where
-  from = intoProto
+unOnChainAddress :: OnChainAddress mrel -> Text
+unOnChainAddress = unOnChainAddress0
 
 unsafeNewOnChainAddress :: Text -> OnChainAddress mrel
 unsafeNewOnChainAddress = OnChainAddress
-
-unOnChainAddress :: OnChainAddress mrel -> Text
-unOnChainAddress = unOnChainAddress0
 
 newOnChainAddress ::
   ( Env m
@@ -97,3 +88,18 @@ newOnChainAddressT ::
   ExceptT Failure m (OnChainAddress mrel)
 newOnChainAddressT =
   ExceptT . newOnChainAddress
+
+instance ToProto (OnChainAddress mrel) Proto.OnChainAddress where
+  toProto =
+    newProtoVal
+      . unOnChainAddress
+
+instance ToProto (OnChainAddress 'Fund) Proto.FundOnChainAddress where
+  toProto =
+    newProtoVal
+      . toProto @(OnChainAddress 'Fund) @Proto.OnChainAddress
+
+instance ToProto (OnChainAddress 'Refund) Proto.RefundOnChainAddress where
+  toProto =
+    newProtoVal
+      . toProto @(OnChainAddress 'Refund) @Proto.OnChainAddress

--- a/btc-lsp/src/BtcLsp/Grpc/Combinator.hs
+++ b/btc-lsp/src/BtcLsp/Grpc/Combinator.hs
@@ -17,6 +17,7 @@ module BtcLsp.Grpc.Combinator
   )
 where
 
+import BtcLsp.Class.FromProto
 import BtcLsp.Data.Type
 import BtcLsp.Import.External as Ext
 import Data.Map as Map
@@ -45,8 +46,7 @@ type GrpcRes res failure specific =
 
 fromReqT ::
   forall a b res failure specific m.
-  ( From a b,
-    'False ~ (a == b),
+  ( FromProto a b,
     GrpcRes res failure specific,
     Monad m
   ) =>
@@ -59,15 +59,14 @@ fromReqT loc =
 
 fromReqE ::
   forall a b res failure specific.
-  ( From a b,
-    'False ~ (a == b),
+  ( FromProto a b,
     GrpcRes res failure specific
   ) =>
   ReversedFieldLocation ->
   Maybe a ->
   Either res b
 fromReqE loc =
-  (from <$>)
+  (fromProto <$>)
     . maybeToRight msg
   where
     msg =

--- a/btc-lsp/src/BtcLsp/Grpc/Orphan.hs
+++ b/btc-lsp/src/BtcLsp/Grpc/Orphan.hs
@@ -1,103 +1,14 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module BtcLsp.Grpc.Orphan
-  ( intoProto,
-    fromProto,
-  )
-where
+module BtcLsp.Grpc.Orphan () where
 
-import BtcLsp.Data.Kind
 import BtcLsp.Data.Orphan ()
-import BtcLsp.Data.Type
 import BtcLsp.Import.External
-import Data.ProtoLens.Field
-import Data.ProtoLens.Message
-import qualified LndClient as Lnd
-import qualified Proto.BtcLsp.Data.HighLevel as Proto
-import qualified Proto.BtcLsp.Data.HighLevel_Fields as Proto
-import qualified Proto.BtcLsp.Data.LowLevel as Proto
-import qualified Proto.BtcLsp.Data.LowLevel_Fields as LowLevel
 import qualified Witch
 
-fromProto ::
-  forall proto through haskell.
-  ( HasField proto "val" through,
-    From through haskell,
-    'False ~ (through == haskell)
-  ) =>
-  proto ->
-  haskell
-fromProto =
-  from
-    . (^. field @"val")
-
-intoProto ::
-  forall proto through haskell.
-  ( Message proto,
-    HasField proto "val" through,
-    From haskell through,
-    'False ~ (haskell == through)
-  ) =>
-  haskell ->
-  proto
-intoProto x =
-  defMessage
-    & field @"val" .~ from x
-
-instance From Proto.Nonce Nonce where
-  from = fromProto
-
-instance From Nonce Proto.Nonce where
-  from = intoProto
-
-instance From Proto.LnPubKey NodePubKey where
-  from =
-    coerce . (^. Proto.val)
-
-instance From NodePubKey Proto.LnPubKey where
-  from x =
-    defMessage
-      & Proto.val .~ coerce x
-
-instance From Proto.LnInvoice (LnInvoice mrel) where
-  from =
-    via @Lnd.PaymentRequest . (^. Proto.val)
-
-instance From (LnInvoice mrel) Proto.LnInvoice where
-  from x =
-    defMessage
-      & Proto.val .~ via @Lnd.PaymentRequest x
-
-instance From Proto.FundLnInvoice (LnInvoice 'Fund) where
-  from = fromProto
-
-instance From (LnInvoice 'Fund) Proto.FundLnInvoice where
-  from = intoProto
-
-instance From Proto.OnChainAddress (UnsafeOnChainAddress 'Refund) where
-  from = fromProto
-
-instance From Proto.RefundOnChainAddress (UnsafeOnChainAddress 'Refund) where
-  from = fromProto
-
-instance From Proto.Privacy Privacy where
-  from = toEnum . fromEnum
-
-instance From Privacy Proto.Privacy where
-  from = toEnum . fromEnum
-
-instance From Proto.Msat MSat where
-  from = fromProto
-
-instance From MSat Proto.Msat where
-  from = intoProto
-
-instance From Proto.FundMoney MSat where
-  from = fromProto
-
-instance From MSat Proto.FundMoney where
-  from = intoProto
+instance From Word64 Msat where
+  from = via @Natural
 
 deriving stock instance Eq CompressMode
 
@@ -107,27 +18,3 @@ instance FromJSON CompressMode
 
 instance From PortNumber Word32 where
   from = fromIntegral -- Word16 to Word32 is fine.
-
-instance From PortNumber Proto.LnPort where
-  from = intoProto
-
-instance From HostName Proto.LnHost where
-  from = intoProto
-
-instance From (Money owner btcl mrel) Proto.Msat where
-  from = intoProto
-
-instance From (Money 'Usr btcl 'Fund) Proto.LocalBalance where
-  from = intoProto
-
-instance From (Money 'Lsp btcl 'Gain) Proto.FeeMoney where
-  from = intoProto
-
-instance From FeeRate Proto.Urational where
-  from (FeeRate x) =
-    defMessage
-      & LowLevel.numerator .~ numerator x
-      & LowLevel.denominator .~ denominator x
-
-instance From FeeRate Proto.FeeRate where
-  from = intoProto

--- a/btc-lsp/src/BtcLsp/Grpc/Server/HighLevel.hs
+++ b/btc-lsp/src/BtcLsp/Grpc/Server/HighLevel.hs
@@ -57,11 +57,12 @@ swapIntoLn userEnt req = do
         & SwapIntoLn.success
           .~ ( defMessage
                  & SwapIntoLn.fundOnChainAddress
-                   .~ from (swapIntoLnFundAddress swap)
+                   .~ toProto (swapIntoLnFundAddress swap)
                  & SwapIntoLn.minFundMoney
-                   .~ from @MSat
-                     ( from (swapIntoLnChanCapUser swap)
-                         + from (swapIntoLnFeeLsp swap)
+                   .~ toProto @(Money 'Usr 'OnChain 'Fund)
+                     ( Money $
+                         unMoney (swapIntoLnChanCapUser swap)
+                           + unMoney (swapIntoLnFeeLsp swap)
                      )
              )
 
@@ -147,22 +148,22 @@ getCfg _ _ = do
                & GetCfg.lspLnNodes
                  .~ [ defMessage
                         & Grpc.pubKey
-                          .~ from pub
+                          .~ toProto pub
                         & Grpc.host
-                          .~ from (socketAddressHost sa)
+                          .~ toProto (socketAddressHost sa)
                         & Grpc.port
-                          .~ from (socketAddressPort sa)
+                          .~ toProto (socketAddressPort sa)
                     ]
                & GetCfg.swapIntoLnMinAmt
-                 .~ from swapMinAmt
+                 .~ toProto swapMinAmt
                & GetCfg.swapIntoLnMaxAmt
-                 .~ from Math.swapLnMaxAmt
+                 .~ toProto Math.swapLnMaxAmt
                & GetCfg.swapFromLnMinAmt
-                 .~ from swapMinAmt
+                 .~ toProto swapMinAmt
                & GetCfg.swapFromLnMaxAmt
-                 .~ from Math.swapLnMaxAmt
+                 .~ toProto Math.swapLnMaxAmt
                & GetCfg.swapLnFeeRate
-                 .~ from Math.swapLnFeeRate
+                 .~ toProto Math.swapLnFeeRate
                & GetCfg.swapLnMinFee
-                 .~ from Math.swapLnMinFee
+                 .~ toProto Math.swapLnMinFee
            )

--- a/btc-lsp/src/BtcLsp/Import.hs
+++ b/btc-lsp/src/BtcLsp/Import.hs
@@ -4,7 +4,9 @@ module BtcLsp.Import
 where
 
 import BtcLsp.Class.Env as X (Env (..))
+import BtcLsp.Class.FromProto as X (FromProto (..))
 import BtcLsp.Class.Storage as X (Storage (..))
+import BtcLsp.Class.ToProto as X (ToProto (..))
 import BtcLsp.Data.Env as X (readRawConfig, withEnv)
 import BtcLsp.Data.Kind as X
 import BtcLsp.Data.Orphan as X ()

--- a/btc-lsp/src/BtcLsp/Import/External.hs
+++ b/btc-lsp/src/BtcLsp/Import/External.hs
@@ -104,7 +104,7 @@ import Katip.Format.Time as X
 import LndClient as X
   ( ChanId (..),
     LndError (..),
-    MSat (..),
+    Msat (..),
     NodePubKey (..),
     RHash (..),
     RPreimage (..),

--- a/btc-lsp/src/BtcLsp/Import/External.hs
+++ b/btc-lsp/src/BtcLsp/Import/External.hs
@@ -117,6 +117,7 @@ import LndClient.Util as X
     txIdHex,
     withSpawnLink,
   )
+import Network.Bitcoin.BtcEnv as X (BtcCfg (..), BtcEnv (..))
 import Network.GRPC.Client as X (CompressMode (..))
 import Network.HTTP2.Client2 as X (HostName, PortNumber)
 import Text.Casing as X (camel)

--- a/btc-lsp/src/BtcLsp/Import/Witch.hs
+++ b/btc-lsp/src/BtcLsp/Import/Witch.hs
@@ -22,6 +22,7 @@ import Witch as X
   ( From,
     TryFrom,
     TryFromException (..),
+    unsafeFrom,
     withSource,
     withTarget,
   )

--- a/btc-lsp/src/BtcLsp/Import/Witch.hs
+++ b/btc-lsp/src/BtcLsp/Import/Witch.hs
@@ -9,7 +9,6 @@ module BtcLsp.Import.Witch
     into,
     via,
     tryFrom,
-    tryVia,
     composeTry,
     composeTryRhs,
     composeTryLhs,
@@ -69,19 +68,6 @@ tryFrom ::
   Either (TryFromException source target) target
 tryFrom =
   Witch.tryFrom @source @target
-
-tryVia ::
-  forall through source target.
-  ( TryFrom source through,
-    TryFrom through target,
-    'False ~ (source == through),
-    'False ~ (through == target)
-  ) =>
-  source ->
-  Either (TryFromException source target) target
-tryVia =
-  tryFrom @through
-    `composeTry` tryFrom
 
 composeTry ::
   forall through source target.

--- a/btc-lsp/src/BtcLsp/Math/OnChain.hs
+++ b/btc-lsp/src/BtcLsp/Math/OnChain.hs
@@ -25,42 +25,42 @@ import qualified Universum
 
 trySatToMsat ::
   Btc.BTC ->
-  Either Failure MSat
+  Either Failure Msat
 trySatToMsat =
   first (FailureInt . FailureMath . Universum.show)
-    . ( from @Word64
+    . ( from @Natural
           `composeTryRhs` tryFrom @Integer
             `composeTryLhs` ((* 1000) . from)
       )
 
 tryMsatToSat ::
-  MSat ->
+  Msat ->
   Either Failure Btc.BTC
 tryMsatToSat =
   first (FailureInt . FailureMath . Universum.show)
     . ( tryFrom @Rational @Btc.BTC
-          `composeTryLhs` ((% 100000000000) . via @Word64)
+          `composeTryLhs` ((% 100000000000) . via @Natural)
       )
 
 trySatToMsatT ::
   ( Monad m
   ) =>
   Btc.BTC ->
-  ExceptT Failure m MSat
+  ExceptT Failure m Msat
 trySatToMsatT =
   except . trySatToMsat
 
 tryMsatToSatT ::
   ( Monad m
   ) =>
-  MSat ->
+  Msat ->
   ExceptT Failure m Btc.BTC
 tryMsatToSatT =
   except . tryMsatToSat
 
-trxDustLimit :: MSat
+trxDustLimit :: Msat
 trxDustLimit =
-  MSat $ 546 * 1000
+  Msat $ 546 * 1000
 
 --
 -- NOTE : estimations are for the P2WPKH only
@@ -138,9 +138,9 @@ trxEstFee ::
   InQty ->
   OutQty ->
   SatPerVbyte ->
-  Either (TryFromException Natural MSat) MSat
+  Msat
 trxEstFee inQty outQty satPerVbyte =
-  (from @Word64 `composeTryRhs` tryFrom)
+  from @Natural
     . (* 1000)
     . (ceiling :: Ratio Natural -> Natural)
     $ from (trxEstSize inQty outQty) * from satPerVbyte

--- a/btc-lsp/src/BtcLsp/Math/Swap.hs
+++ b/btc-lsp/src/BtcLsp/Math/Swap.hs
@@ -42,7 +42,7 @@ swapExpiryLimitInternal =
 
 swapLnMaxAmt :: Money 'Usr btcl 'Fund
 swapLnMaxAmt =
-  Money $ MSat 10000000000
+  Money $ Msat 10000000000
 
 swapLnFeeRate :: FeeRate
 swapLnFeeRate =
@@ -50,7 +50,7 @@ swapLnFeeRate =
 
 swapLnMinFee :: Money 'Lsp btcl 'Gain
 swapLnMinFee =
-  Money $ MSat 2000000
+  Money $ Msat 2000000
 
 newSwapCapM ::
   ( Env m
@@ -67,23 +67,23 @@ newSwapCapM usrAmt = do
           SwapCap
             { swapCapUsr = usrLn,
               swapCapLsp = coerce usrLn,
-              swapCapFee = from @Word64 $ ceiling feeRat
+              swapCapFee = from @Natural $ ceiling feeRat
             }
   where
-    usrFin :: Ratio Word64
+    usrFin :: Ratio Natural
     usrFin =
       from usrAmt % 1
-    feeRat :: Ratio Word64
+    feeRat :: Ratio Natural
     feeRat =
-      from @Word64
+      from @Natural
         . (* 1000)
         . ceiling
         . (/ 1000)
         . max (from swapLnMinFee % 1)
-        $ usrFin * from swapLnFeeRate
+        $ usrFin * unFeeRate swapLnFeeRate
     usrLn :: Money 'Usr 'Ln 'Fund
     usrLn =
-      from @Word64
+      from @Natural
         . floor
         $ usrFin - feeRat
 
@@ -91,21 +91,21 @@ newSwapIntoLnMinAmt ::
   Money 'Chan 'Ln 'Fund ->
   Money 'Usr 'OnChain 'Fund
 newSwapIntoLnMinAmt minCap =
-  from @Word64
+  from @Natural
     . (* 1000)
     . ceiling
     $ usrInitMsat / 1000
   where
-    minFee :: Ratio Word64
+    minFee :: Ratio Natural
     minFee =
       from swapLnMinFee % 1
-    usrFin :: Ratio Word64
+    usrFin :: Ratio Natural
     usrFin =
       from minCap % 2
-    usrPerc :: Ratio Word64
+    usrPerc :: Ratio Natural
     usrPerc =
-      usrFin / (1 - from swapLnFeeRate)
-    usrInitMsat :: Ratio Word64
+      usrFin / (1 - unFeeRate swapLnFeeRate)
+    usrInitMsat :: Ratio Natural
     usrInitMsat =
       if usrPerc - usrFin >= minFee
         then usrPerc

--- a/btc-lsp/src/BtcLsp/Psbt/Utils.hs
+++ b/btc-lsp/src/BtcLsp/Psbt/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 module BtcLsp.Psbt.Utils
   ( swapUtxoToPsbtUtxo,
     psbtShim,
@@ -43,10 +45,10 @@ swapUtxoToPsbtUtxo :: SwapUtxo -> PsbtUtxo
 swapUtxoToPsbtUtxo x =
   PsbtUtxo
     ( OP.OutPoint
-        (coerce $ swapUtxoTxid x)
-        (coerce $ swapUtxoVout x)
+        (unTxId $ swapUtxoTxid x)
+        (unsafeFrom @Natural @Word32 . unVout $ swapUtxoVout x)
     )
-    (coerce $ swapUtxoAmount x)
+    (unMoney $ swapUtxoAmount x)
     (swapUtxoLockId x)
 
 psbtShim :: Lnd.PendingChannelId -> PS.PsbtShim
@@ -57,7 +59,7 @@ psbtShim pcid =
       PS.noPublish = False
     }
 
-fundPsbtReq :: [OP.OutPoint] -> Map Text MSat -> FP.FundPsbtRequest
+fundPsbtReq :: [OP.OutPoint] -> Map Text Msat -> FP.FundPsbtRequest
 fundPsbtReq inputs outputs =
   FP.FundPsbtRequest
     { FP.account = "",

--- a/btc-lsp/src/BtcLsp/Storage/Model/LnChan.hs
+++ b/btc-lsp/src/BtcLsp/Storage/Model/LnChan.hs
@@ -47,8 +47,8 @@ createUpdateSql swapId txid vout = do
         lnChanInsertedAt = ct,
         lnChanUpdatedAt = ct,
         lnChanTransactedAt = ct,
-        lnChanTotalSatoshisReceived = MSat 0,
-        lnChanTotalSatoshisSent = MSat 0
+        lnChanTotalSatoshisReceived = Msat 0,
+        lnChanTotalSatoshisSent = Msat 0
       }
     [ LnChanSwapIntoLnId Psql.=. Psql.val (Just swapId),
       LnChanUpdatedAt Psql.=. Psql.val ct
@@ -207,8 +207,8 @@ upsertChannelPointSql ct ss (Lnd.ChannelPoint txid vout) =
               lnChanInsertedAt = ct,
               lnChanUpdatedAt = ct,
               lnChanTransactedAt = ct,
-              lnChanTotalSatoshisReceived = MSat 0,
-              lnChanTotalSatoshisSent = MSat 0
+              lnChanTotalSatoshisReceived = Msat 0,
+              lnChanTotalSatoshisSent = Msat 0
             }
           [ LnChanStatus
               Psql.=. Psql.val ss,
@@ -244,8 +244,8 @@ closedChannelUpsert ct close =
             lnChanInsertedAt = ct,
             lnChanUpdatedAt = ct,
             lnChanTransactedAt = ct,
-            lnChanTotalSatoshisReceived = MSat 0,
-            lnChanTotalSatoshisSent = MSat 0
+            lnChanTotalSatoshisReceived = Msat 0,
+            lnChanTotalSatoshisSent = Msat 0
           }
         [ LnChanExtId
             Psql.=. Psql.val extId,

--- a/btc-lsp/src/BtcLsp/Storage/Model/User.hs
+++ b/btc-lsp/src/BtcLsp/Storage/Model/User.hs
@@ -27,7 +27,7 @@ createVerifySql pub nonce = do
   let zeroRow =
         User
           { userNodePubKey = pub,
-            userLatestNonce = from @Word64 0,
+            userLatestNonce = Nonce 0,
             userInsertedAt = ct,
             userUpdatedAt = ct
           }

--- a/btc-lsp/src/BtcLsp/Storage/Model/User.hs
+++ b/btc-lsp/src/BtcLsp/Storage/Model/User.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-
 module BtcLsp.Storage.Model.User
   ( createVerifySql,
   )

--- a/btc-lsp/src/BtcLsp/Thread/BlockScanner.hs
+++ b/btc-lsp/src/BtcLsp/Thread/BlockScanner.hs
@@ -99,7 +99,7 @@ maybeFundSwap swapId = do
       . inspect
 
 data Utxo = Utxo
-  { utxoAmt :: MSat,
+  { utxoAmt :: Msat,
     utxoVout :: Vout 'Funding,
     utxoTxId :: TxId 'Funding,
     utxoSwapId :: SwapIntoLnId,
@@ -151,7 +151,7 @@ handleAddr addr amt vout txid = do
 newUtxo ::
   ( Env m
   ) =>
-  Either Failure MSat ->
+  Either Failure Msat ->
   Either (TryFromException Integer (Vout 'Funding)) (Vout 'Funding) ->
   Either LndError ByteString ->
   Entity SwapIntoLn ->
@@ -380,7 +380,8 @@ scanOneBlock height = do
 --
 
 utxoToOutPoint :: Utxo -> OP.OutPoint
-utxoToOutPoint u = OP.OutPoint (coerce $ utxoTxId u) (coerce $ utxoVout u)
+utxoToOutPoint u =
+  OP.OutPoint (unTxId $ utxoTxId u) (unsafeFrom . unVout $ utxoVout u)
 
 lockUtxo' :: Env m => Utxo -> ExceptT Failure m Utxo
 lockUtxo' u = do

--- a/btc-lsp/src/BtcLsp/Thread/Refunder.hs
+++ b/btc-lsp/src/BtcLsp/Thread/Refunder.hs
@@ -44,8 +44,8 @@ apply =
 
 data SendUtxosResult = SendUtxosResult
   { getGetDecTrx :: Btc.DecodedRawTransaction,
-    getTotalAmt :: MSat,
-    getFee :: MSat
+    getTotalAmt :: Msat,
+    getFee :: Msat
   }
 
 newtype TxLabel = TxLabel
@@ -68,12 +68,11 @@ sendUtxos ::
   ExceptT Failure m SendUtxosResult
 sendUtxos feeRate utxos addr txLabel = do
   inQty <- tryFromT "SendUtxos length" $ length utxos
-  estFee <-
-    tryFailureT "SendUtxos fee estimator" $
-      Math.trxEstFee
-        (Math.InQty inQty)
-        (Math.OutQty 1)
-        feeRate
+  let estFee =
+        Math.trxEstFee
+          (Math.InQty inQty)
+          (Math.OutQty 1)
+          feeRate
   let finalOutputAmt = totalInputsAmt - estFee
   when (finalOutputAmt < Math.trxDustLimit) . throwE $
     FailureInt . FailurePrivate $
@@ -118,7 +117,7 @@ newFundPsbtReq ::
   Math.SatPerVbyte ->
   [PsbtUtxo] ->
   OnChainAddress 'Refund ->
-  MSat ->
+  Msat ->
   FP.FundPsbtRequest
 newFundPsbtReq feeRate utxos' outAddr est = do
   let mtpl =

--- a/btc-lsp/src/BtcLsp/Time.hs
+++ b/btc-lsp/src/BtcLsp/Time.hs
@@ -39,7 +39,7 @@ addSeconds =
     . fromRational
     . toRational
     . secondsToDiffTime
-    . via @Word64
+    . via @Natural
 
 subSeconds :: Lnd.Seconds -> UTCTime -> UTCTime
 subSeconds =
@@ -48,7 +48,7 @@ subSeconds =
     . toRational
     . secondsToDiffTime
     . (* (-1))
-    . via @Word64
+    . via @Natural
 
 swapExpiryLimit :: Lnd.Seconds
 swapExpiryLimit =

--- a/btc-lsp/src/BtcLsp/Yesod/Data/Widget.hs
+++ b/btc-lsp/src/BtcLsp/Yesod/Data/Widget.hs
@@ -87,16 +87,6 @@ fromTextField =
     txtField :: Field m Text
     txtField = textField
 
-toText ::
-  ( From a Text,
-    'False ~ (Text == a),
-    'False ~ (a == Text)
-  ) =>
-  a ->
-  Text
-toText =
-  from
-
 newListWidget ::
   [[(AppMessage, AppMessage)]] ->
   Maybe Widget

--- a/btc-lsp/src/BtcLsp/Yesod/Handler/SwapIntoLnSelect.hs
+++ b/btc-lsp/src/BtcLsp/Yesod/Handler/SwapIntoLnSelect.hs
@@ -208,7 +208,7 @@ newSwapWidget swapInfo =
 totalOnChainAmt ::
   (SwapUtxoStatus -> Bool) ->
   SwapIntoLn.SwapInfo ->
-  MSat
+  Msat
 totalOnChainAmt only =
   from
     . sum
@@ -244,8 +244,8 @@ newUtxoWidget utxos =
               ),
               ( MsgVout,
                 MsgProxy
-                  . inspectPlain @Word32
-                  $ coerce swapUtxoVout
+                  . inspectPlain
+                  $ unVout swapUtxoVout
               ),
               ( MsgInsertedAt,
                 MsgUtcTime swapUtxoInsertedAt
@@ -272,8 +272,8 @@ newChanWidget chans =
               ),
               ( MsgVout,
                 MsgProxy
-                  . inspectPlain @Word32
-                  $ coerce lnChanFundingVout
+                  . inspectPlain
+                  $ unVout lnChanFundingVout
               ),
               ( MsgInsertedAt,
                 MsgUtcTime lnChanInsertedAt

--- a/btc-lsp/src/BtcLsp/Yesod/Handler/SwapIntoLnSelect.hs
+++ b/btc-lsp/src/BtcLsp/Yesod/Handler/SwapIntoLnSelect.hs
@@ -7,6 +7,7 @@ module BtcLsp.Yesod.Handler.SwapIntoLnSelect
   )
 where
 
+import BtcLsp.Data.Smart
 import BtcLsp.Data.Type
 import qualified BtcLsp.Math.Swap as Math
 import BtcLsp.Storage.Model
@@ -74,7 +75,7 @@ getSwapIntoLnSelectR uuid = do
           maybeM badMethod pure
             . pure
             . toQr
-            $ from swapIntoLnFundAddress
+            $ unOnChainAddress swapIntoLnFundAddress
         let mSwapWidget = newSwapWidget swapInfo
         let mUtxoWidget = newUtxoWidget swapInfoUtxo
         let mChanWidget = newChanWidget swapInfoChan
@@ -175,12 +176,12 @@ newSwapWidget swapInfo =
         ( MsgSwapIntoLnFundAddress,
           Just
             . MsgProxy
-            $ toText swapIntoLnFundAddress
+            $ unOnChainAddress swapIntoLnFundAddress
         ),
         ( MsgSwapIntoLnRefundAddress,
           Just
             . MsgProxy
-            $ toText swapIntoLnRefundAddress
+            $ unOnChainAddress swapIntoLnRefundAddress
         ),
         ( MsgInsertedAt,
           Just $

--- a/btc-lsp/src/BtcLsp/Yesod/Import/NoFoundation.hs
+++ b/btc-lsp/src/BtcLsp/Yesod/Import/NoFoundation.hs
@@ -12,7 +12,7 @@ import BtcLsp.Data.Type as Import
 import BtcLsp.Import.External as Import
   ( ExceptT (..),
     IsList,
-    MSat (..),
+    Msat (..),
     Natural,
     NodePubKey (..),
     Pool,

--- a/btc-lsp/templates/swap_into_ln_select.hamlet
+++ b/btc-lsp/templates/swap_into_ln_select.hamlet
@@ -1,7 +1,7 @@
 $if swapIntoLnStatus == SwapWaitingFundChain
-  <img .img-responsive.center-block.small-margin-bottom src=#{fundAddrQr} alt=#{toText swapIntoLnFundAddress}>
+  <img .img-responsive.center-block.small-margin-bottom src=#{fundAddrQr} alt=#{unOnChainAddress swapIntoLnFundAddress}>
   <div .input-group.extra-large-margin-bottom>
-    <input .form-control id=#{htmlUuid} type="text" value=#{toText swapIntoLnFundAddress} readonly>
+    <input .form-control id=#{htmlUuid} type="text" value=#{unOnChainAddress swapIntoLnFundAddress} readonly>
     <span .input-group-btn>
       <button .btn.btn-primary type="button" data-clipboard-target="##{htmlUuid}" autofocus>
         _{MsgCopy}

--- a/btc-lsp/test/BlockScannerSpec.hs
+++ b/btc-lsp/test/BlockScannerSpec.hs
@@ -22,7 +22,7 @@ spec = do
     wbal <- withBtcT Btc.getBalance id
     let amt = wbal / 10
     trAddr <-
-      from
+      unOnChainAddress
         . swapIntoLnFundAddress
         . entityVal
         <$> createDummySwap Nothing
@@ -47,7 +47,7 @@ spec = do
     wbal <- withBtcT Btc.getBalance id
     let amt = wbal / 10
     trAddr <-
-      from
+      unOnChainAddress
         . swapIntoLnFundAddress
         . entityVal
         <$> createDummySwap Nothing
@@ -75,7 +75,7 @@ spec = do
     swapEnt <-
       createDummySwap Nothing
     let trAddr =
-          from
+          unOnChainAddress
             . swapIntoLnFundAddress
             $ entityVal swapEnt
     satsToSend <-

--- a/btc-lsp/test/BlockScannerSpec.hs
+++ b/btc-lsp/test/BlockScannerSpec.hs
@@ -41,7 +41,7 @@ spec = do
         . Math.trySatToMsat
         $ amt * 2
     utxos <- BlockScanner.scan
-    let gotAmt :: MSat = sum $ BlockScanner.utxoAmt <$> utxos
+    let gotAmt :: Msat = sum $ BlockScanner.utxoAmt <$> utxos
     liftIO $ expectedAmt `shouldBe` gotAmt
   itEnvT @'LndLsp "Block scanner works with 2 blocks" $ do
     wbal <- withBtcT Btc.getBalance id

--- a/btc-lsp/test/LnChanWatcherSpec.hs
+++ b/btc-lsp/test/LnChanWatcherSpec.hs
@@ -24,8 +24,8 @@ openChannelRequest ::
 openChannelRequest nodePubkey =
   OpenChannel.OpenChannelRequest
     { OpenChannel.nodePubkey = nodePubkey,
-      OpenChannel.localFundingAmount = MSat 200000000,
-      OpenChannel.pushMSat = Just $ MSat 10000000,
+      OpenChannel.localFundingAmount = Msat 200000000,
+      OpenChannel.pushMSat = Just $ Msat 10000000,
       OpenChannel.targetConf = Nothing,
       OpenChannel.mSatPerByte = Nothing,
       OpenChannel.private = Nothing,

--- a/btc-lsp/test/LnChanWatcherSpec.hs
+++ b/btc-lsp/test/LnChanWatcherSpec.hs
@@ -92,7 +92,7 @@ testFun = do
         lndFrom
         (openChannelRequest toPubKey)
   isPendingOpenOk <-
-    tryTimes 3 1 $
+    tryTimes 5 1 $
       justTrue
         . fmap
           ( (== LnChanStatusPendingOpen)
@@ -101,14 +101,14 @@ testFun = do
           )
         <$> queryChannel cp
   mine 10 LndLsp
-  isOpenedOk <- tryTimes 3 1 $ do
+  isOpenedOk <- tryTimes 5 1 $ do
     ch <- fmap entityVal <$> queryChannel cp
     let r =
           and
             <$> sequence
               [(== LnChanStatusActive) . lnChanStatus <$> ch]
     pure $ justTrue r
-  isBackedUp <- tryTimes 3 1 $ do
+  isBackedUp <- tryTimes 5 1 $ do
     ch <- fmap entityVal <$> queryChannel cp
     let r =
           and
@@ -122,7 +122,7 @@ testFun = do
           (const $ pure ())
           lndFrom
           (closeChannelRequest cp)
-  isInactivedOk <- tryTimes 3 1 $ do
+  isInactivedOk <- tryTimes 5 1 $ do
     ch <- fmap entityVal <$> queryChannel cp
     let r =
           and
@@ -130,7 +130,7 @@ testFun = do
               [(== LnChanStatusInactive) . lnChanStatus <$> ch]
     pure $ justTrue r
   mine 10 LndLsp
-  isClosedOk <- tryTimes 3 1 $ do
+  isClosedOk <- tryTimes 5 1 $ do
     ch <- fmap entityVal <$> queryChannel cp
     let r =
           and

--- a/btc-lsp/test/MathSpec.hs
+++ b/btc-lsp/test/MathSpec.hs
@@ -50,7 +50,7 @@ spec = do
     withRunInIO $ \run0 ->
       pure . monadicIO $ do
         swp <-
-          from @MSat <$> pick arbitrary
+          from @Msat <$> pick arbitrary
         maybeM
           (assert $ swp < minSwp)
           ( \res -> do
@@ -82,9 +82,9 @@ spec = do
       )
       satMsat
   where
-    satMsat :: [(Btc.BTC, MSat)]
+    satMsat :: [(Btc.BTC, Msat)]
     satMsat =
-      [ (0.00000001, MSat 1000),
-        (0.00000101, MSat 101000),
-        (1.00000101, MSat 100000101000)
+      [ (0.00000001, Msat 1000),
+        (0.00000101, Msat 101000),
+        (1.00000101, Msat 100000101000)
       ]

--- a/btc-lsp/test/PsbtOpenerSpec.hs
+++ b/btc-lsp/test/PsbtOpenerSpec.hs
@@ -44,8 +44,8 @@ spec = do
     swp <- createDummySwap Nothing
     let swpId = entityKey swp
     let swpAddr = swapIntoLnFundAddress . entityVal $ swp
-    void $ sendAmt (from swpAddr) (from (10 * amt))
-    void $ sendAmt (from swpAddr) (from (10 * amt))
+    void $ sendAmt (unOnChainAddress swpAddr) (from (10 * amt))
+    void $ sendAmt (unOnChainAddress swpAddr) (from (10 * amt))
     void putLatestBlockToDB
     lift $ mine 4 LndLsp
     void BlockScanner.scan
@@ -90,8 +90,8 @@ spec = do
     swp <- createDummySwap Nothing
     let swpId = entityKey swp
     let swpAddr = swapIntoLnFundAddress . entityVal $ swp
-    void $ sendAmt (from swpAddr) (from (10 * amt))
-    void $ sendAmt (from swpAddr) (from (10 * amt))
+    void $ sendAmt (unOnChainAddress swpAddr) (from (10 * amt))
+    void $ sendAmt (unOnChainAddress swpAddr) (from (10 * amt))
     void putLatestBlockToDB
     lift $ mine 4 LndLsp
     void BlockScanner.scan
@@ -134,8 +134,8 @@ spec = do
     let swp1Addr = swapIntoLnFundAddress . entityVal $ swp1
 
     let amt = Msat (50000 * 1000)
-    void $ transferCoinsToAddr amt LndAlice (from swp0Addr)
-    void $ transferCoinsToAddr amt LndAlice (from swp1Addr)
+    void $ transferCoinsToAddr amt LndAlice (unOnChainAddress swp0Addr)
+    void $ transferCoinsToAddr amt LndAlice (unOnChainAddress swp1Addr)
 
     void putLatestBlockToDB
 

--- a/btc-lsp/test/PsbtOpenerSpec.hs
+++ b/btc-lsp/test/PsbtOpenerSpec.hs
@@ -27,15 +27,15 @@ import TestHelpers
 import TestOrphan ()
 import qualified UnliftIO.STM as T
 
-sendAmt :: Env m => Text -> MSat -> ExceptT Failure m ()
+sendAmt :: Env m => Text -> Msat -> ExceptT Failure m ()
 sendAmt addr amt =
   void $
     withLndT
       Lnd.sendCoins
       ($ SendCoins.SendCoinsRequest {SendCoins.addr = addr, SendCoins.amount = amt, SendCoins.sendAll = False})
 
-lspFee :: MSat
-lspFee = MSat 20000 * 1000
+lspFee :: Msat
+lspFee = Msat 20000 * 1000
 
 spec :: Spec
 spec = do
@@ -78,7 +78,7 @@ spec = do
         )
     $(logTM) DebugS $ logStr $ "Channel is opened:" <> inspect chnls
     let (openedChanMaybe :: Maybe CH.Channel) = find (\c -> CH.channelPoint c == chan) chnls
-    let (expectedRemoteBalance :: MSat) = coerce (20 * amt) - lspFee
+    let (expectedRemoteBalance :: Msat) = coerce (20 * amt) - lspFee
     case openedChanMaybe of
       Just c -> do
         liftIO $ do
@@ -133,7 +133,7 @@ spec = do
     let swp1Id = entityKey swp1
     let swp1Addr = swapIntoLnFundAddress . entityVal $ swp1
 
-    let amt = MSat (50000 * 1000)
+    let amt = Msat (50000 * 1000)
     void $ transferCoinsToAddr amt LndAlice (from swp0Addr)
     void $ transferCoinsToAddr amt LndAlice (from swp1Addr)
 

--- a/btc-lsp/test/RefunderSpec.hs
+++ b/btc-lsp/test/RefunderSpec.hs
@@ -84,7 +84,7 @@ spec = do
         ( $
             SendCoins.SendCoinsRequest
               { SendCoins.addr =
-                  from
+                  unOnChainAddress
                     . swapIntoLnFundAddress
                     . entityVal
                     $ swp,

--- a/btc-lsp/test/ReorgSpec.hs
+++ b/btc-lsp/test/ReorgSpec.hs
@@ -6,10 +6,11 @@ module ReorgSpec
 where
 
 import BtcLsp.Grpc.Orphan ()
-import BtcLsp.Import hiding (setGrpcCtx, setGrpcCtxT)
+import BtcLsp.Import hiding (setGrpcCtx, setGrpcCtxT, withBtcT)
 import qualified BtcLsp.Storage.Model.Block as Block
 import qualified BtcLsp.Thread.BlockScanner as BlockScanner
 import qualified Network.Bitcoin as Btc
+import Network.Bitcoin.BtcMultiEnv
 import Test.Hspec
 import TestAppM
 import TestOrphan ()
@@ -17,12 +18,12 @@ import TestOrphan ()
 spec :: Spec
 spec = do
   itEnvT @'LndLsp "Reorg test" $ do
-    void $ withBtcT Btc.setNetworkActive ($ False)
+    void $ withBtcT LndLsp Btc.setNetworkActive ($ False)
     _ <- BlockScanner.scan
 
-    void $ withBtcT Btc.generate (\h -> h 5 Nothing)
-    void $ withBtc2T Btc.generate (\h -> h 10 Nothing)
-    blockCount <- withBtcT Btc.getBlockCount id
+    void $ withBtcT LndLsp Btc.generate (\h -> h 5 Nothing)
+    void $ withBtcT LndAlice Btc.generate (\h -> h 10 Nothing)
+    blockCount <- withBtcT LndLsp Btc.getBlockCount id
     _ <- BlockScanner.scan
     blkList1 <-
       lift . runSql
@@ -30,10 +31,10 @@ spec = do
         . BlkHeight
         $ fromIntegral blockCount
     let blk1 = unsafeHead $ entityVal <$> blkList1
-    blockHash1 <- withBtcT Btc.getBlockHash ($ blockCount)
+    blockHash1 <- withBtcT LndLsp Btc.getBlockHash ($ blockCount)
     liftIO $ from (blockHash blk1) `shouldBe` blockHash1
 
-    void $ withBtcT Btc.setNetworkActive ($ True)
+    void $ withBtcT LndLsp Btc.setNetworkActive ($ True)
     _ <- lift waitTillNodesSynchronized
     _ <- BlockScanner.scan
     blkList2 <-
@@ -42,7 +43,7 @@ spec = do
         . BlkHeight
         $ fromIntegral blockCount
     let blk2 = unsafeHead $ entityVal <$> blkList2
-    blockHash2 <- withBtcT Btc.getBlockHash ($ blockCount)
+    blockHash2 <- withBtcT LndLsp Btc.getBlockHash ($ blockCount)
     liftIO $ from (blockHash blk2) `shouldBe` blockHash2
 
 unsafeHead :: [Block] -> Block
@@ -53,17 +54,18 @@ unsafeHead blkList = do
 
 waitTillNodesSynchronized ::
   ( MonadReader (TestEnv o) m,
-    Env m
+    Env m,
+    BtcMultiEnv m Failure TestOwner
   ) =>
   m (Either Failure ())
 waitTillNodesSynchronized = runExceptT $ do
   sleep1s
-  blockCount1 <- withBtcT Btc.getBlockCount id
-  blockCount2 <- withBtc2T Btc.getBlockCount id
+  blockCount1 <- withBtcT LndLsp Btc.getBlockCount id
+  blockCount2 <- withBtcT LndAlice Btc.getBlockCount id
   if blockCount1 == blockCount2
     then do
-      blockHash1 <- withBtcT Btc.getBlockHash ($ blockCount1)
-      blockHash2 <- withBtc2T Btc.getBlockHash ($ blockCount2)
+      blockHash1 <- withBtcT LndLsp Btc.getBlockHash ($ blockCount1)
+      blockHash2 <- withBtcT LndAlice Btc.getBlockHash ($ blockCount2)
       if blockHash1 == blockHash2
         then return ()
         else ExceptT waitTillNodesSynchronized

--- a/btc-lsp/test/ServerSpec.hs
+++ b/btc-lsp/test/ServerSpec.hs
@@ -72,7 +72,7 @@ spec = forM_ [Compressed, Uncompressed] $ \compressMode -> do
                        & GetCfg.lspLnNodes
                          .~ [ defMessage
                                 & Proto.pubKey
-                                  .~ from pub
+                                  .~ toProto pub
                                 & Proto.host
                                   .~ ( defMessage
                                          & Proto.val .~ "127.0.0.1"
@@ -115,7 +115,7 @@ spec = forM_ [Compressed, Uncompressed] $ \compressMode -> do
           LndAlice
           ( defMessage
               & SwapIntoLn.refundOnChainAddress
-                .~ from @(OnChainAddress 'Refund) refundAddr
+                .~ toProto @(OnChainAddress 'Refund) refundAddr
           )
 
     liftIO $

--- a/btc-lsp/test/SmartSpec.hs
+++ b/btc-lsp/test/SmartSpec.hs
@@ -27,7 +27,7 @@ spec = do
                 }
           )
     res <- Smart.newOnChainAddressT $ from raw
-    liftIO $ raw `shouldBe` from res
+    liftIO $ raw `shouldBe` unOnChainAddress res
   itEnv @'LndLsp "newOnChainAddressT fails" $ do
     res <- runExceptT $ do
       raw <-

--- a/btc-lsp/test/TestAppM.hs
+++ b/btc-lsp/test/TestAppM.hs
@@ -534,10 +534,8 @@ setGrpcCtxT owner message = do
     message
       & field @"ctx"
         .~ ( defMessage
-               & Proto.nonce
-                 .~ from @Nonce @Proto.Nonce nonce
-               & Proto.lnPubKey
-                 .~ from @Lnd.NodePubKey @Proto.LnPubKey pubKey
+               & Proto.nonce .~ toProto nonce
+               & Proto.lnPubKey .~ toProto pubKey
            )
 
 forkThread ::

--- a/btc-lsp/test/TestHelpers.hs
+++ b/btc-lsp/test/TestHelpers.hs
@@ -64,9 +64,9 @@ createDummySwap mExpAt = do
   lift . runSql $
     SwapIntoLn.createIgnoreSql
       usr
-      (from fundAddr)
-      (from changeAndFeeAddr)
-      (from refundAddr)
+      (unsafeNewOnChainAddress $ Lnd.address fundAddr)
+      (unsafeNewOnChainAddress $ Lnd.address changeAndFeeAddr)
+      (unsafeNewOnChainAddress $ Lnd.address refundAddr)
       expAt
       Public
 

--- a/btc-lsp/test/TestHelpers.hs
+++ b/btc-lsp/test/TestHelpers.hs
@@ -111,7 +111,7 @@ waitCond times condition st = do
 
 transferCoinsRaw ::
   Bool ->
-  MSat ->
+  Msat ->
   TestOwner ->
   TestOwner ->
   ExceptT Failure (TestAppM 'LndLsp IO) ()
@@ -127,17 +127,17 @@ transferAllCoins ::
   TestOwner ->
   TestOwner ->
   ExceptT Failure (TestAppM 'LndLsp IO) ()
-transferAllCoins = transferCoinsRaw True (MSat 0)
+transferAllCoins = transferCoinsRaw True (Msat 0)
 
 transferCoins ::
-  MSat ->
+  Msat ->
   TestOwner ->
   TestOwner ->
   ExceptT Failure (TestAppM 'LndLsp IO) ()
 transferCoins = transferCoinsRaw False
 
 transferCoinsToAddr ::
-  MSat ->
+  Msat ->
   TestOwner ->
   Text ->
   ExceptT Failure (TestAppM 'LndLsp IO) ()

--- a/btc-lsp/test/TestHelpers.hs
+++ b/btc-lsp/test/TestHelpers.hs
@@ -146,4 +146,10 @@ transferCoinsToAddr amt fromOwner toAddr = do
     withLndTestT
       fromOwner
       Lnd.sendCoins
-      ($ SendCoins.SendCoinsRequest {SendCoins.addr = coerce toAddr, SendCoins.amount = amt, SendCoins.sendAll = False})
+      ( $
+          SendCoins.SendCoinsRequest
+            { SendCoins.addr = coerce toAddr,
+              SendCoins.amount = amt,
+              SendCoins.sendAll = False
+            }
+      )

--- a/btc-lsp/test/TestOrphan.hs
+++ b/btc-lsp/test/TestOrphan.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module TestOrphan () where
@@ -15,4 +16,6 @@ instance From (OnChainAddress 'Refund) Lnd.NewAddressResponse where
   from =
     coerce . unOnChainAddress
 
-deriving newtype instance Arbitrary MSat
+instance Arbitrary Msat where
+  arbitrary =
+    Msat . from <$> arbitrary @Word64

--- a/cabal.project
+++ b/cabal.project
@@ -12,8 +12,8 @@ package witch
 source-repository-package
   type: git
   location: https://github.com/coingaming/lnd-client.git
-  --sha256: sha256-OFd/D6krKz2nIDUnPjobmrEr+CJCuMSbogSI+OiVeH4=
-  tag: aa64314c725cf2666043631b46e0567cd9824138
+  --sha256: sha256-+3NZKbv1vMYs9ySlkxSEG/pWhgaJeB9guv7HUakLMDo=
+  tag: bbf362379e631b13a37e1230835a634ff435d0c6
 
 source-repository-package
   type: git

--- a/electrs-client/src/ElectrsClient/Type.hs
+++ b/electrs-client/src/ElectrsClient/Type.hs
@@ -9,7 +9,7 @@ import ElectrsClient.Import.External
 
 data RpcError
   = RpcNoAddress
-  | RpcJsonDecodeError
+  | RpcJsonDecodeError ByteString Text
   | RpcHexDecodeError
   | CannotSyncBlockchain
   | OtherError Text

--- a/electrs-client/test/Main.hs
+++ b/electrs-client/test/Main.hs
@@ -4,12 +4,15 @@ module Main
 where
 
 import ElectrsClient.Import.External
+import qualified Network.Bitcoin as Btc
+import qualified Network.Bitcoin.BtcEnv as Btc
 import qualified Spec
 import Test.Hspec.Formatters
 import Test.Hspec.Runner
 
 main :: IO ()
 main = do
+  void $ Btc.withBtc Btc.generate $ \f -> f 105 Nothing
   hspecWith
     defaultConfig
       { configFormatter = Just progress

--- a/generic-pretty-instances/src/Text/PrettyPrint/GenericPretty/Instance.hs
+++ b/generic-pretty-instances/src/Text/PrettyPrint/GenericPretty/Instance.hs
@@ -11,6 +11,7 @@ where
 import qualified Control.Exception as Exception
 import qualified Crypto.Secp256k1 as Secp256k1
 import Data.ByteString.Base16 as B16 (encode)
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Fixed as Fixed
 import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Wire
@@ -133,6 +134,10 @@ instance Out TL.Text where
 instance Out ByteString where
   docPrec n = docPrec n . newBsDoc
   doc = doc . newBsDoc
+
+instance Out BL.ByteString where
+  docPrec n = docPrec n . BL.toStrict
+  doc = doc . BL.toStrict
 
 instance (Out a) => Out (Vector a) where
   docPrec n = docPrec n . toList

--- a/network-bitcoin/network-bitcoin.cabal
+++ b/network-bitcoin/network-bitcoin.cabal
@@ -43,6 +43,8 @@ Library
     Network.Bitcoin.RawTransaction
     Network.Bitcoin.Types
     Network.Bitcoin.Wallet
+    Network.Bitcoin.BtcEnv
+    Network.Bitcoin.BtcMultiEnv
 
   Build-depends:
     aeson >= 0.8,
@@ -58,7 +60,8 @@ Library
     base == 4.*,
     time >= 1.4.2,
     http-client >= 0.4.6,
-    network-uri
+    network-uri,
+    transformers
 
 Source-repository head
   type: git

--- a/network-bitcoin/src/Network/Bitcoin/BtcEnv.hs
+++ b/network-bitcoin/src/Network/Bitcoin/BtcEnv.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wall #-}
 

--- a/network-bitcoin/src/Network/Bitcoin/BtcEnv.hs
+++ b/network-bitcoin/src/Network/Bitcoin/BtcEnv.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Network.Bitcoin.BtcEnv
+  ( BtcEnv (..),
+    BtcCfg (..),
+    BtcFailure (..),
+    newBtcClient,
+    tryBtcMethod,
+  )
+where
+
+import Control.Exception (Handler (..), catches)
+import Control.Monad (void)
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Except
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import GHC.Generics (Generic)
+import Network.Bitcoin.Internal
+import Network.Bitcoin.Wallet (WalletCfg)
+import qualified Network.Bitcoin.Wallet as Wallet
+import Network.HTTP.Client (HttpException)
+
+class (MonadIO m) => BtcEnv m where
+  getBtcCfg :: m BtcCfg
+  getBtcClient :: m Client
+  withBtc :: (Client -> a) -> (a -> IO b) -> m (Either BtcFailure b)
+  withBtc method args = do
+    cfg <- getBtcCfg
+    client <- getBtcClient
+    tryBtcMethod cfg client method args
+  withBtcT :: (Client -> a) -> (a -> IO b) -> ExceptT BtcFailure m b
+  withBtcT method =
+    ExceptT . withBtc method
+
+data BtcCfg = BtcCfg
+  { btcCfgHost :: Text,
+    btcCfgUsername :: Text,
+    btcCfgPassword :: Text,
+    btcCfgAutoLoadWallet :: Maybe WalletCfg
+  }
+  deriving stock
+    ( Eq,
+      Ord,
+      Generic
+    )
+
+data BtcFailure
+  = BtcFailureRpc BitcoinException
+  | BtcFailureHttp HttpException
+  deriving stock
+    ( Show,
+      Generic
+    )
+
+newBtcClient :: (MonadIO m) => BtcCfg -> m Client
+newBtcClient cfg =
+  liftIO $
+    getClient
+      (T.unpack $ btcCfgHost cfg)
+      (T.encodeUtf8 $ btcCfgUsername cfg)
+      (T.encodeUtf8 $ btcCfgPassword cfg)
+
+tryBtcMethod ::
+  ( MonadIO m
+  ) =>
+  BtcCfg ->
+  Client ->
+  (Client -> a) ->
+  (a -> IO b) ->
+  m (Either BtcFailure b)
+tryBtcMethod cfg client method args = do
+  res <- tryBtcMethodInternal client method args
+  case (res, btcCfgAutoLoadWallet cfg) of
+    -- https://github.com/bitcoin/bitcoin/blob/48174c0f287b19931ca110670610bd03a03eb914/src/rpc/protocol.h#L80
+    (Left (BtcFailureRpc (BitcoinApiError (-18) _)), Just wallet) -> do
+      let name = Wallet.walletCfgWalletName wallet
+      let load = Wallet.walletCfgLoadOnStartup wallet
+      void $ tryBtcMethodInternal client Wallet.createWallet ($ wallet)
+      void $ tryBtcMethodInternal client Wallet.loadWallet (\f -> f name load)
+      tryBtcMethodInternal client method args
+    _ ->
+      pure res
+
+tryBtcMethodInternal ::
+  ( MonadIO m
+  ) =>
+  Client ->
+  (Client -> a) ->
+  (a -> IO b) ->
+  m (Either BtcFailure b)
+tryBtcMethodInternal client method args =
+  liftIO $
+    (Right <$> args (method client))
+      `catches` [ Handler
+                    ( \(e :: BitcoinException) ->
+                        pure . Left $ BtcFailureRpc e
+                    ),
+                  Handler
+                    ( \(e :: HttpException) ->
+                        pure . Left $ BtcFailureHttp e
+                    )
+                ]

--- a/network-bitcoin/src/Network/Bitcoin/BtcMultiEnv.hs
+++ b/network-bitcoin/src/Network/Bitcoin/BtcMultiEnv.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Network.Bitcoin.BtcMultiEnv
+  ( BtcMultiEnv (..),
+  )
+where
+
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Except
+import Network.Bitcoin.BtcEnv (BtcCfg (..), BtcFailure (..), tryBtcMethod)
+import Network.Bitcoin.Internal
+
+class (MonadIO m) => BtcMultiEnv m owner where
+  getBtcCfg :: owner -> m BtcCfg
+  getBtcClient :: owner -> m Client
+  withBtc :: owner -> (Client -> a) -> (a -> IO b) -> m (Either BtcFailure b)
+  withBtc owner method args = do
+    cfg <- getBtcCfg owner
+    client <- getBtcClient owner
+    tryBtcMethod cfg client method args
+  withBtcT :: owner -> (Client -> a) -> (a -> IO b) -> ExceptT BtcFailure m b
+  withBtcT owner method =
+    ExceptT . withBtc owner method

--- a/network-bitcoin/src/Network/Bitcoin/BtcMultiEnv.hs
+++ b/network-bitcoin/src/Network/Bitcoin/BtcMultiEnv.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wall #-}
 
 module Network.Bitcoin.BtcMultiEnv

--- a/network-bitcoin/src/Network/Bitcoin/BtcMultiEnv.hs
+++ b/network-bitcoin/src/Network/Bitcoin/BtcMultiEnv.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wall #-}
 
@@ -9,17 +10,20 @@ where
 
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
+import Data.Bifunctor (first)
 import Network.Bitcoin.BtcEnv (BtcCfg (..), BtcFailure (..), tryBtcMethod)
 import Network.Bitcoin.Internal
 
-class (MonadIO m) => BtcMultiEnv m owner where
+class (MonadIO m) => BtcMultiEnv m e owner | m -> e owner where
   getBtcCfg :: owner -> m BtcCfg
   getBtcClient :: owner -> m Client
-  withBtc :: owner -> (Client -> a) -> (a -> IO b) -> m (Either BtcFailure b)
+  getBtcFailureMaker :: owner -> m (BtcFailure -> e)
+  withBtc :: owner -> (Client -> a) -> (a -> IO b) -> m (Either e b)
   withBtc owner method args = do
     cfg <- getBtcCfg owner
     client <- getBtcClient owner
-    tryBtcMethod cfg client method args
-  withBtcT :: owner -> (Client -> a) -> (a -> IO b) -> ExceptT BtcFailure m b
+    failureMaker <- getBtcFailureMaker owner
+    first failureMaker <$> tryBtcMethod cfg client method args
+  withBtcT :: owner -> (Client -> a) -> (a -> IO b) -> ExceptT e m b
   withBtcT owner method =
     ExceptT . withBtc owner method

--- a/network-bitcoin/src/Network/Bitcoin/Types.hs
+++ b/network-bitcoin/src/Network/Bitcoin/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# OPTIONS_GHC -Wall #-}
@@ -14,6 +15,7 @@ module Network.Bitcoin.Types ( Client
                              ) where
 
 import           Control.Exception
+import           GHC.Generics (Generic)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Fixed
 import           Data.Text            (Text)
@@ -41,7 +43,7 @@ data BitcoinException = BitcoinApiError Int Text
                       | BitcoinResultTypeError BL.ByteString
                       -- ^ The raw JSON returned, if we can't figure out what
                       --   actually went wrong.
-    deriving ( Show, Read, Ord, Eq, Typeable )
+    deriving ( Show, Read, Ord, Eq, Typeable, Generic )
 
 instance Exception BitcoinException
 

--- a/network-bitcoin/src/Test/Main.hs
+++ b/network-bitcoin/src/Test/Main.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 
 module Main where
@@ -42,7 +43,7 @@ main = defaultMain . testGroup "network-bitcoin tests" $
 client :: IO Client
 client = getClient "http://127.0.0.1:18443" "developer" "developer"
 
-instance BtcEnv IO where
+instance BtcEnv IO BtcFailure where
   getBtcCfg =
     pure BtcCfg
       { btcCfgHost = "http://127.0.0.1:18443" ,
@@ -52,6 +53,8 @@ instance BtcEnv IO where
       }
   getBtcClient =
     client
+  getBtcFailureMaker =
+    pure id
 
 
 nbTest name = testProperty name . once . monadicIO

--- a/nix/bitcoin-conf.nix
+++ b/nix/bitcoin-conf.nix
@@ -51,8 +51,6 @@ let
   init = writeShellScriptBin "init" ''
     echo "init"
     export PATH="${lib.makeBinPath [cli]}"
-    bitcoin-cli createwallet "testwallet"
-    bitcoin-cli generatetoaddress 1 "$(bitcoin-cli getnewaddress)"
     bitcoin-cli getblockchaininfo '';
   stop = writeShellScriptBin "stop" ''
     echo "Stop"

--- a/nix/ci-release.sh
+++ b/nix/ci-release.sh
@@ -7,11 +7,17 @@ BTC_LSP_BUILD_DIR="$THIS_DIR/../btc-lsp/build"
 ELECTRS_CLIENT_BUILD_DIR="$THIS_DIR/../electrs-client/build"
 mkdir -p "$BTC_LSP_BUILD_DIR"
 mkdir -p "$ELECTRS_CLIENT_BUILD_DIR"
+rm -rf "$BTC_LSP_BUILD_DIR/docker-image-btc-lsp.tar.gz"
+rm -rf "$BTC_LSP_BUILD_DIR/docker-image-integration.tar.gz"
+rm -rf "$ELECTRS_CLIENT_BUILD_DIR/docker-image-electrs.tar.gz"
 
 echo "btc-lsp ==> Binaries build"
-nix-build btc-lsp/nix/docker.nix --out-link "$BTC_LSP_BUILD_DIR/docker-image-btc-lsp.tar.gz"
-nix-build btc-lsp/nix/docker-integration.nix --out-link "$BTC_LSP_BUILD_DIR/docker-image-integration.tar.gz"
-nix-build electrs-client/nix/docker-image-electrs.nix --out-link "$ELECTRS_CLIENT_BUILD_DIR/docker-image-electrs.tar.gz"
+nix-build nix/docker-btc-lsp.nix \
+  --out-link "$BTC_LSP_BUILD_DIR/docker-image-btc-lsp.tar.gz"
+nix-build nix/docker-btc-lsp-integration.nix \
+  --out-link "$BTC_LSP_BUILD_DIR/docker-image-integration.tar.gz"
+nix-build nix/docker-electrs.nix \
+  --out-link "$ELECTRS_CLIENT_BUILD_DIR/docker-image-electrs.tar.gz"
 
 echo "btc-lsp ==> Docker btc-lsp image verification"
 docker load -q -i \

--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -1,0 +1,39 @@
+{ exitOnLowCoverage ? true }:
+let
+  project = import ./project.nix;
+  src = project.prjSrc;
+  repoDir = builtins.toString ./..;
+  deps = import ./test-deps.nix {inherit repoDir;};
+  nixPkgs = project.nixPkgs;
+  projectWithCov = project.project {
+    src = repoDir;
+    extraModules = [{
+      packages.btc-lsp.components.library.doCoverage = true;
+    }];
+  };
+  exeVer = projectWithCov.btc-lsp.components.exes.btc-lsp-exe.version;
+  coverageReport = projectWithCov.btc-lsp.coverageReport;
+  exitOnLowCoverageSh = if exitOnLowCoverage then "exit 1" else "";
+in
+  nixPkgs.runCommand "coverage-test" {} ''
+      set -euo pipefail
+
+      mkdir $out
+      cp -R ${coverageReport}/* $out
+
+      EXPECTED_COV=${project.expectedTestCoveragePercent}
+      PROVIDED_COV=$(${nixPkgs.haskell.compiler.ghc902}/bin/hpc report \
+        --hpcdir=${coverageReport}/share/hpc/vanilla/mix/coins-${exeVer} \
+        ${coverageReport}/share/hpc/vanilla/tix/coins-${exeVer}/coins-${exeVer}.tix \
+        | grep "expressions used" | grep -oP '\d+(?=%)')
+
+      echo "coverage-test ==> $PROVIDED_COV% is the provided test coverage."
+      echo "coverage-test ==> $EXPECTED_COV% is the minimal test coverage."
+      if [[ $PROVIDED_COV -lt $EXPECTED_COV ]]
+      then
+        echo "coverage-test ==> Test coverage is too low! Failing!"
+        ${exitOnLowCoverageSh}
+      else
+        echo "coverage-test ==> Test coverage is sufficient! Success!"
+      fi
+    ''

--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -3,12 +3,17 @@ let
   project = import ./project.nix;
   src = project.prjSrc;
   repoDir = builtins.toString ./..;
-  deps = import ./test-deps.nix {inherit repoDir;};
+  deps = import ./test-deps.nix {
+    inherit repoDir;
+  };
   nixPkgs = project.nixPkgs;
   projectWithCov = project.project {
     src = repoDir;
     extraModules = [{
       packages.btc-lsp.components.library.doCoverage = true;
+      packages.btc-lsp.components.tests.btc-lsp-test.preCheck = ''
+        source ${deps.envFile}
+      '';
     }];
   };
   exeVer = projectWithCov.btc-lsp.components.exes.btc-lsp-exe.version;

--- a/nix/docker-btc-lsp-integration.nix
+++ b/nix/docker-btc-lsp-integration.nix
@@ -1,0 +1,18 @@
+{
+  profile ? false,
+}:
+with (import ./project.nix);
+let
+  exe = (project {}).btc-lsp.components.exes.btc-lsp-integration;
+  hspec = nixPkgs.haskellPackages.hspec;
+  hspec-discover = nixPkgs.haskellPackages.hspec-discover;
+in
+  nixPkgs.dockerTools.buildImage {
+    name = "ghcr.io/coingaming/btc-lsp-integration";
+    contents = [
+      exe
+    ];
+    config = {
+      Cmd = [ "${exe}/bin/btc-lsp-integration" ];
+    };
+  }

--- a/nix/docker-btc-lsp.nix
+++ b/nix/docker-btc-lsp.nix
@@ -1,0 +1,29 @@
+{
+  profile ? false,
+}:
+with (import ./project.nix);
+let
+  exe = (project {}).btc-lsp.components.exes.btc-lsp-exe;
+  static = nixPkgs.stdenv.mkDerivation {
+    name = "static";
+    src = ./../btc-lsp;
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p $out/
+      cp -R ./config/ $out/
+      cp -R ./static/ $out/
+    '';
+  };
+in
+  nixPkgs.dockerTools.buildImage {
+    name = "ghcr.io/coingaming/btc-lsp";
+    tag = "${exe.version}";
+    contents = [
+      exe
+      static # static might be not needed
+    ];
+    config = {
+      Cmd = [ "${exe}/bin/btc-lsp-exe" ];
+      ExposedPorts = { "50051/tcp" = {}; };
+    };
+  }

--- a/nix/docker-electrs.nix
+++ b/nix/docker-electrs.nix
@@ -1,0 +1,28 @@
+let
+  header = (import ./header.nix);
+  pkgs = header.nixPkgs;
+  electrs = pkgs.electrs;
+  entrypoint = pkgs.writeShellScriptBin "entrypoint" ''
+    echo "auth='$BITCOIND_USER:$BITCOIND_PASSWORD'" \
+      >> /.electrs/electrs.toml && \
+    echo "log_filters = 'INFO'" \
+      >> /.electrs/electrs.toml && \
+    ${electrs}/bin/electrs \
+      --conf="/.electrs/electrs.toml" \
+      --db-dir="/.electrs/db" \
+      --network="$NETWORK" \
+      --electrum-rpc-addr="$ELECTRUM_RPC_ADDR" \
+      --daemon-rpc-addr="$DAEMON_RPC_ADDR" \
+      --wait-duration-secs="$WAIT_DURATION_SECS" \
+      --jsonrpc-import \
+      --timestamp
+  '';
+in
+  pkgs.dockerTools.buildImage {
+    name = "ghcr.io/coingaming/electrs";
+    contents = [ entrypoint ];
+    config = {
+      Cmd = [ "${entrypoint}/bin/entrypoint" ];
+      ExposedPorts = { "80/tcp" = {}; };
+    };
+  }

--- a/nix/postgres-conf.nix
+++ b/nix/postgres-conf.nix
@@ -19,9 +19,9 @@ let
     cp -f ${postgresqlconf} ${workDir}/postgresql.conf
   '';
   init = writeShellScriptBin "init" ''
-    ${postgresql}/bin/createuser -s postgres -h "/tmp"
-    ${postgresql}/bin/createdb -h localhost lsp
-    ${postgresql}/bin/createdb -h localhost lsp-test
+    ${postgresql}/bin/createuser -s postgres -h "/tmp" || true
+    ${postgresql}/bin/createdb -h localhost lsp || true
+    ${postgresql}/bin/createdb -h localhost lsp-test || true
   '';
   start = writeShellScriptBin "start" ''
     ${postgresql}/bin/postgres -D ${workDir} > ${workDir}/postgres.log 2>&1 &

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -12,9 +12,12 @@ in
   nixPkgsLegacy = header.nixPkgsLegacy;
   nixBitcoin = header.nixBitcoin;
   expectedTestCoveragePercent="55";
-  project = {}: pkgs.haskell-nix.project {
+  project = {
+    src ? prjSrc,
+    extraModules ? []
+  }: pkgs.haskell-nix.project {
+    inherit src;
     projectFileName = "cabal.project";
-    src = prjSrc;
     compiler-nix-name = header.compiler-nix-name;
     modules = [{
       packages.generic-pretty-instances.components.tests.generic-pretty-instances-test.build-tools = [
@@ -29,6 +32,6 @@ in
       packages.electrs-client.components.tests.electrs-client-test.build-tools = [
         pkgs.haskellPackages.hspec-discover
       ];
-    }];
+    }] ++ extraModules;
   };
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -2,19 +2,16 @@ let
   header = (import ./header.nix);
   pkgs = header.pkgs;
   prjSrc = pkgs.haskell-nix.haskellLib.cleanGit {
-    name = "coins-src-all";
+    name = "src-all";
     src = ../.;
   };
 in
 {
-  pkgs = pkgs;
+  inherit pkgs prjSrc;
   nixPkgs = header.nixPkgs;
   nixPkgsLegacy = header.nixPkgsLegacy;
   nixBitcoin = header.nixBitcoin;
-  prjSrc = pkgs.haskell-nix.haskellLib.cleanGit {
-    name = "coins-src-all";
-    src = ../.;
-  };
+  expectedTestCoveragePercent="55";
   project = {}: pkgs.haskell-nix.project {
     projectFileName = "cabal.project";
     src = prjSrc;
@@ -24,6 +21,9 @@ in
         pkgs.haskellPackages.hspec-discover
       ];
       packages.btc-lsp.components.tests.btc-lsp-test.build-tools = [
+        pkgs.haskellPackages.hspec-discover
+      ];
+      packages.btc-lsp.components.exes.btc-lsp-integration.build-tools = [
         pkgs.haskellPackages.hspec-discover
       ];
       packages.electrs-client.components.tests.electrs-client-test.build-tools = [

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -3,7 +3,6 @@ let
   proto = import ./proto-lens-protoc.nix;
   repoDir = builtins.toString ./..;
   deps = import ./test-deps.nix {
-    dataDir = "./build";
     inherit repoDir;
   };
 in

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,7 +1,11 @@
 with (import ./project.nix);
 let
   proto = import ./proto-lens-protoc.nix;
-  deps = import ./test-deps.nix {dataDir = "./build";};
+  repoDir = builtins.toString ./..;
+  deps = import ./test-deps.nix {
+    dataDir = "./build";
+    inherit repoDir;
+  };
 in
   (project {}).shellFor {
   withHoogle = true;
@@ -31,6 +35,8 @@ in
     deps.ormoluTest
     deps.hlintTest
     deps.mine
+    deps.coverageTest
+    deps.coverageHtml
     nixBitcoin.lndinit
   ];
   tools = {

--- a/nix/test-deps.nix
+++ b/nix/test-deps.nix
@@ -1,6 +1,7 @@
-{ repoDir }:
+{ repoDir,
+  dataDir ? "${repoDir}/build",
+}:
 let
-  dataDir = "${repoDir}/build";
   project =  (import ./project.nix);
   nixPkgs = project.nixPkgs;
   prjSrc = project.prjSrc;

--- a/nix/test-deps.nix
+++ b/nix/test-deps.nix
@@ -1,4 +1,4 @@
-{ dataDir }:
+{ dataDir, repoDir }:
 let
   project =  (import ./project.nix);
   nixPkgs = project.nixPkgs;
@@ -75,6 +75,29 @@ let
     echo "test-deps ==> done"
   '';
   envFile = lspEnv.exportEnvFile;
+  spawnTestEnv = nixPkgs.writeShellScriptBin "spawn-test-env" ''
+    set -euo pipefail
+    ${nixPkgs.hpack}/bin/hpack ${repoDir}/btc-lsp
+    ${nixPkgs.hpack}/bin/hpack ${repoDir}/electrs-client
+    (${nixPkgs.util-linux}/bin/setsid ${startAll}/bin/start-test-deps & wait)
+  '';
+  coverageTest = nixPkgs.writeShellScriptBin "coverage-test" ''
+    set -euo pipefail
+    ${spawnTestEnv}/bin/spawn-test-env
+    ${nixPkgs.nix}/bin/nix-build \
+      --show-trace \
+      --option sandbox false \
+      ${repoDir}/nix/coverage.nix
+  '';
+  coverageHtml = nixPkgs.writeShellScriptBin "coverage-html" ''
+    set -euo pipefail
+    ${spawnTestEnv}/bin/spawn-test-env
+    ${nixPkgs.nix}/bin/nix-build \
+      --show-trace \
+      --option sandbox false \
+      --arg exitOnLowCoverage false \
+      ${repoDir}/nix/coverage.nix
+  '';
 in
 {
   cliAlias = nixPkgs.writeShellScriptBin "cli-alias" ''
@@ -172,6 +195,11 @@ in
 
     echo "==> mined enough blocks"
   '';
-  inherit envFile startAll bitcoindConf;
+  inherit envFile
+          startAll
+          bitcoindConf
+          spawnTestEnv
+          coverageTest
+          coverageHtml;
 }
 

--- a/nix/test-deps.nix
+++ b/nix/test-deps.nix
@@ -1,5 +1,6 @@
-{ dataDir, repoDir }:
+{ repoDir }:
 let
+  dataDir = "${repoDir}/build";
   project =  (import ./project.nix);
   nixPkgs = project.nixPkgs;
   prjSrc = project.prjSrc;

--- a/test.nix
+++ b/test.nix
@@ -4,7 +4,10 @@ let
   p = project.project {};
   src = project.prjSrc;
   nixPkgs = project.nixPkgs;
-  deps = import ./nix/test-deps.nix {dataDir = ".";};
+  deps = import ./nix/test-deps.nix {
+    dataDir = ".";
+    repoDir = builtins.toString ./.;
+  };
   networkBitcoinTest = p.network-bitcoin.components.tests.network-bitcoin-tests;
   genericPrettyInstancesTest = p.generic-pretty-instances.components.tests.generic-pretty-instances-test;
   btcLspTest = p.btc-lsp.components.tests.btc-lsp-test;

--- a/test.nix
+++ b/test.nix
@@ -5,7 +5,6 @@ let
   src = project.prjSrc;
   nixPkgs = project.nixPkgs;
   deps = import ./nix/test-deps.nix {
-    dataDir = ".";
     repoDir = builtins.toString ./.;
   };
   networkBitcoinTest = p.network-bitcoin.components.tests.network-bitcoin-tests;

--- a/test.nix
+++ b/test.nix
@@ -6,6 +6,7 @@ let
   nixPkgs = project.nixPkgs;
   deps = import ./nix/test-deps.nix {
     repoDir = builtins.toString ./.;
+    dataDir = ".";
   };
   networkBitcoinTest = p.network-bitcoin.components.tests.network-bitcoin-tests;
   genericPrettyInstancesTest = p.generic-pretty-instances.components.tests.generic-pretty-instances-test;


### PR DESCRIPTION
- `BtcEnv` and `BtcMultiEnv` new classes in `network-bitcoin` with corresponding new modules, with better method combinators to use bitcoind JSON RPC.
- Removed `withBtc` and `withBtcT` from big `Env` class of `BtcLsp`, and implemented new `network-bitcoin` classes where it's needed. 
- Removed bitcoind wallet initialization and initial mining from some shell scripts, everything should be handled by haskell now.
- `BtcCfg` record where optional auto-loaded wallet could be configured.
- New `createWallet` and `loadWallet` bitcoind RPCs.
- `callApi` network-bitcoin bugfixes.
- `lnd-client` upgrade, corresponding refactoring, mostly Word64 -> Natural for numeric lnd values.
- Replaced the most `Witch` stuff and instances with separate `ToProto` and `FromProto` instances and non-generic constructors/accessors (un*).
- Using monorepo nix infrastructure for builds to use local versions of network-bitcoin and other libs.
- Added coverage tools.
- More old/obsolete local nix infra cleanup needed, more `Witch` cleanup needed (will create new task).
- Need to eliminate `coerce` from the code.